### PR TITLE
Added request and response logging for debugging reasons

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -300,6 +300,7 @@ class Proxy(multiprocessing.Process):
         self.server = None
         
         self.request = HttpParser()
+        print "REQUEST: %s\n" % self.request
         self.response = HttpParser(HTTP_RESPONSE_PARSER)
         
         self.connection_established_pkt = CRLF.join([

--- a/proxy.py
+++ b/proxy.py
@@ -329,8 +329,7 @@ class Proxy(multiprocessing.Process):
         
         # parse http request
         self.request.parse(data)
-        # print "REQUEST: %s\n" % self.request
-        
+
         # once http request parser has reached the state complete
         # we attempt to establish connection to destination server
         if self.request.state == HTTP_PARSER_STATE_COMPLETE:
@@ -362,8 +361,9 @@ class Proxy(multiprocessing.Process):
                     del_headers=['proxy-connection', 'connection', 'keep-alive'], 
                     add_headers=[('Connection', 'Close')]
                 ))
+        print "REQUEST METHOD: %s at %s" % (self.request.method, self.request.url)
         print "REQUEST HEADERS: %s\n" % self.request.headers
-        print "REQUET BODY: %s \n" % self.request.body
+        print "REQUEST BODY: %s \n" % self.request.body
     
     def _process_response(self, data):
         # parse incoming response packet

--- a/proxy.py
+++ b/proxy.py
@@ -82,8 +82,7 @@ class HttpParser(object):
     def __init__(self, type=None):
         self.state = HTTP_PARSER_STATE_INITIALIZED
         self.type = type if type else HTTP_REQUEST_PARSER
-        print "TYPE: %s \n" % self.type
-        
+
         self.raw = ''
         self.buffer = ''
         
@@ -127,7 +126,8 @@ class HttpParser(object):
                     self.body = self.chunker.body
                     self.state = HTTP_PARSER_STATE_COMPLETE
 
-            print ("Response Headers: %s \n Response Body: %s" % (self.headers, self.body))
+            logging.info("RESPONSE >>")
+            logging.info("Response Headers: %s \n Response Body: %s" % (self.headers, self.body))
             return False, ''
         
         line, data = HttpParser.split(data)
@@ -301,8 +301,7 @@ class Proxy(multiprocessing.Process):
         
         self.request = HttpParser()
         self.response = HttpParser(HTTP_RESPONSE_PARSER)
-        print "RESPONSE: %s\n" % self.response
-        
+
         self.connection_established_pkt = CRLF.join([
             'HTTP/1.1 200 Connection established',
             'Proxy-agent: proxy.py v%s' % __version__,
@@ -361,9 +360,10 @@ class Proxy(multiprocessing.Process):
                     del_headers=['proxy-connection', 'connection', 'keep-alive'], 
                     add_headers=[('Connection', 'Close')]
                 ))
-        print "REQUEST METHOD: %s at %s" % (self.request.method, self.request.url)
-        print "REQUEST HEADERS: %s\n" % self.request.headers
-        print "REQUEST BODY: %s \n" % self.request.body
+        logging.info("REQUESTS >>")
+        logging.info("REQUEST METHOD: %s at %s" % (self.request.method, self.request.url))
+        logging.info("REQUEST HEADERS: %s\n" % self.request.headers)
+        logging.info("REQUEST BODY: %s \n" % self.request.body)
     
     def _process_response(self, data):
         # parse incoming response packet

--- a/proxy.py
+++ b/proxy.py
@@ -363,7 +363,7 @@ class Proxy(multiprocessing.Process):
                     add_headers=[('Connection', 'Close')]
                 ))
         print "REQUEST HEADERS: %s\n" % self.request.headers
-        print "REQUET BODY: %S \n" % self.request.body
+        print "REQUET BODY: %s \n" % self.request.body
     
     def _process_response(self, data):
         # parse incoming response packet

--- a/proxy.py
+++ b/proxy.py
@@ -300,8 +300,8 @@ class Proxy(multiprocessing.Process):
         self.server = None
         
         self.request = HttpParser()
-        print "REQUEST: %s\n" % self.request
         self.response = HttpParser(HTTP_RESPONSE_PARSER)
+        print "RESPONSE: %s\n" % self.response
         
         self.connection_established_pkt = CRLF.join([
             'HTTP/1.1 200 Connection established',
@@ -329,6 +329,7 @@ class Proxy(multiprocessing.Process):
         
         # parse http request
         self.request.parse(data)
+        # print "REQUEST: %s\n" % self.request
         
         # once http request parser has reached the state complete
         # we attempt to establish connection to destination server
@@ -361,6 +362,7 @@ class Proxy(multiprocessing.Process):
                     del_headers=['proxy-connection', 'connection', 'keep-alive'], 
                     add_headers=[('Connection', 'Close')]
                 ))
+        print "REQUEST: %s\n" % self.request
     
     def _process_response(self, data):
         # parse incoming response packet

--- a/proxy.py
+++ b/proxy.py
@@ -362,7 +362,8 @@ class Proxy(multiprocessing.Process):
                     del_headers=['proxy-connection', 'connection', 'keep-alive'], 
                     add_headers=[('Connection', 'Close')]
                 ))
-        print "REQUEST: %s\n" % self.request
+        print "REQUEST HEADERS: %s\n" % self.request.headers
+        print "REQUET BODY: %S \n" % self.request.body
     
     def _process_response(self, data):
         # parse incoming response packet

--- a/proxy.py
+++ b/proxy.py
@@ -125,7 +125,8 @@ class HttpParser(object):
                 if self.chunker.state == CHUNK_PARSER_STATE_COMPLETE:
                     self.body = self.chunker.body
                     self.state = HTTP_PARSER_STATE_COMPLETE
-            
+
+            print ("Response Headers: %s \n Response Body: %s" % (self.headers, self.body))
             return False, ''
         
         line, data = HttpParser.split(data)

--- a/proxy.py
+++ b/proxy.py
@@ -82,6 +82,7 @@ class HttpParser(object):
     def __init__(self, type=None):
         self.state = HTTP_PARSER_STATE_INITIALIZED
         self.type = type if type else HTTP_REQUEST_PARSER
+        print "TYPE: %s \n" % self.type
         
         self.raw = ''
         self.buffer = ''


### PR DESCRIPTION
While using this proxy, even though I was able to do my job by just transferring packages through this, I could not debug anything. I needed to know the request my code was sending and the response I'd receive back, in order to check if everything was okay. And this kind of logging might be helpful anyway.