### PR TITLE
 Fix a bug when parsing chunked data

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -403,9 +403,9 @@ class Proxy(multiprocessing.Process):
         host, port = self.server.addr if self.server else (None, None)
         if self.request.method == b"CONNECT":
             logger.info("%s:%s - %s %s:%s" % (self.client.addr[0], self.client.addr[1], self.request.method, host, port))
-        else:
+        elif self.request.method:
             logger.info("%s:%s - %s %s:%s%s - %s %s - %s bytes" % (self.client.addr[0], self.client.addr[1], self.request.method, host, port, self.request.build_url(), self.response.code, self.response.reason, len(self.response.raw)))
-    
+        
     def _get_waitable_lists(self):
         rlist, wlist, xlist = [self.client.conn], [], []
         logger.debug('*** watching client for read ready')
@@ -556,7 +556,7 @@ def main():
     parser.add_argument('--log-level', default='INFO', help='DEBUG, INFO, WARNING, ERROR, CRITICAL')
     args = parser.parse_args()
     
-    logging.basicConfig(level=getattr(logging, args.log_level), format='%(asctime)s - %(process)d - %(message)s')
+    logging.basicConfig(level=getattr(logging, args.log_level), format='%(asctime)s - %(levelname)s - pid:%(process)d - %(message)s')
     
     hostname = args.hostname
     port = int(args.port)

--- a/proxy.py
+++ b/proxy.py
@@ -81,11 +81,14 @@ class ChunkParser(object):
         self.state = CHUNK_PARSER_STATE_WAITING_FOR_SIZE
         self.body = b''
         self.chunk = b''
+        self.data = b''
         self.size = None
     
     def parse(self, data):
+        data = self.data + data
         more = True if len(data) > 0 else False
         while more: more, data = self.process(data)
+        self.data = data
     
     def process(self, data):
         if self.state == CHUNK_PARSER_STATE_WAITING_FOR_SIZE:

--- a/proxy.py
+++ b/proxy.py
@@ -90,7 +90,7 @@ class ChunkParser(object):
         while more: more, data = self.process(data)
         self.data = data
 
-  def process(self, data):
+    def process(self, data):
         if self.state == CHUNK_PARSER_STATE_WAITING_FOR_SIZE:
             line, data = HttpParser.split(data)
             if line == False: return line, data

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     url                 = proxy.__homepage__,
     license             = proxy.__license__,
     py_modules          = ['proxy'],
-    scripts             = ['proxy/__init__.py'],
+    scripts             = ['proxy.py'],
     install_requires    = [],
     classifiers         = classifiers
 )

--- a/tests.py
+++ b/tests.py
@@ -3,12 +3,12 @@ from proxy import *
 from proxy import bytes_, text_
 
 
-class TestChunkParser1(unittest.TestCase):
+class TestChunkParser(unittest.TestCase):
 
     def setUp(self):
         self.parser = ChunkParser()
 
-    def test_chunk_parse1(self):
+    def test_chunk_parse(self):
         self.parser.parse(b''.join([
             b'4\r\n',
             b'Wiki\r\n',
@@ -23,13 +23,9 @@ class TestChunkParser1(unittest.TestCase):
         self.assertEqual(self.parser.size, None)
         self.assertEqual(self.parser.body, b'Wikipedia in\r\n\r\nchunks.')
         self.assertEqual(self.parser.state, CHUNK_PARSER_STATE_COMPLETE)
+        self.assertEqual(self.parser.data, b'')
 
-class TestChunkParser2(unittest.TestCase):
-
-    def setUp(self):
-        self.parser = ChunkParser()
-
-    def test_chunk_parse2(self):
+    def test_chunk_parser_issue_27(self):
         self.parser.parse(b''.join([
             b'4\r\n',
             b'Wiki\r',
@@ -44,6 +40,7 @@ class TestChunkParser2(unittest.TestCase):
         self.assertEqual(self.parser.size, None)
         self.assertEqual(self.parser.body, b'Wikipedia in\r\n\r\nchunks.')
         self.assertEqual(self.parser.state, CHUNK_PARSER_STATE_COMPLETE)
+        self.assertEqual(self.parser.data, b'')
 
 class TestHttpParser(unittest.TestCase):
 

--- a/tests.py
+++ b/tests.py
@@ -4,16 +4,37 @@ from proxy import *
 from proxy import bytes_, text_
 
 
-class TestChunkParser(unittest.TestCase):
+class TestChunkParser1(unittest.TestCase):
 
     def setUp(self):
         self.parser = ChunkParser()
 
-    def test_chunk_parse(self):
+    def test_chunk_parse1(self):
         self.parser.parse(b''.join([
             b'4\r\n',
             b'Wiki\r\n',
             b'5\r\n',
+            b'pedia\r\n',
+            b'E\r\n',
+            b' in\r\n\r\nchunks.\r\n',
+            b'0\r\n',
+            b'\r\n'
+        ]))
+        self.assertEqual(self.parser.chunk, b'')
+        self.assertEqual(self.parser.size, None)
+        self.assertEqual(self.parser.body, b'Wikipedia in\r\n\r\nchunks.')
+        self.assertEqual(self.parser.state, CHUNK_PARSER_STATE_COMPLETE)
+
+class TestChunkParser2(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = ChunkParser()
+
+    def test_chunk_parse2(self):
+        self.parser.parse(b''.join([
+            b'4\r\n',
+            b'Wiki\r',
+            b'\n5\r\n',
             b'pedia\r\n',
             b'E\r\n',
             b' in\r\n\r\nchunks.\r\n',


### PR DESCRIPTION
If the data ends with the size without CRLF, this patch can prevent the parser from raising an error.

Test program:

    from proxy import *
    cp = ChunkParser()
    data1 = b'3\r\nabc\r\n4'
    data2 = b'\r\nabcd\r\n'
    cp.parse(data1)			# error
    # would be correct if do `cp.parse(data1 + data2)`