### PR TITLE
Use ipaddress type and avoid explicit Connection: close header to upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ coverage:
 	open htmlcov/index.html
 
 lint:
-	flake8 --ignore=E501,W504 --builtins="unicode" proxy.py
-	flake8 --ignore=E501,W504 tests.py
 	autopep8 --recursive --in-place --aggressive --aggressive proxy.py
 	autopep8 --recursive --in-place --aggressive --aggressive tests.py
+	flake8 --ignore=E501,W504 --builtins="unicode" proxy.py
+	flake8 --ignore=E501,W504 tests.py
 
 container:
 	docker build -t $(LATEST_TAG) -t $(IMAGE_TAG) .

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License](https://img.shields.io/github/license/abhinavsingh/proxy.py.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![PyPi Downloads](https://img.shields.io/pypi/dm/proxy.py.svg)](https://pypi.org/project/proxy.py/)
 [![Build Status](https://travis-ci.org/abhinavsingh/proxy.py.svg?branch=develop)](https://travis-ci.org/abhinavsingh/proxy.py/)
+[![No Dependencies](https://david-dm.org/dwyl/esta.svg)](https://github.com/abhinavsingh/proxy.py)
 [![Coverage](https://coveralls.io/repos/github/abhinavsingh/proxy.py/badge.svg?branch=develop)](https://coveralls.io/github/abhinavsingh/proxy.py?branch=develop)
 
 [![Python 3.5](https://img.shields.io/badge/python-3.5-blue.svg)](https://www.python.org/downloads/release/python-350/)
@@ -10,6 +11,7 @@
 [![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
 
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://gitHub.com/abhinavsingh/proxy.py/graphs/commit-activity)
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/abhinavsingh/proxy.py/issues)
 [![Ask Me Anything](https://img.shields.io/badge/Ask%20me-anything-1abc9c.svg)](https://twitter.com/imoracle)
 
 Features
@@ -17,7 +19,7 @@ Features
 
 - Lightweight
     - Distributed as a single file module `~50KB`
-    - Uses only `RAM <20MB` for general use cases
+    - Uses only `~5-20MB` RAM
     - No external dependency other than standard Python library
 - Programmable
     - Optionally enable builtin Web Server

--- a/proxy.py
+++ b/proxy.py
@@ -976,10 +976,13 @@ class HttpProxyPlugin(HttpProtocolBasePlugin):
                 [b'proxy-authorization', b'proxy-connection'])
             # - For HTTP/1.0, connection header defaults to close
             # - For HTTP/1.1, connection header defaults to keep-alive
-            # b'connection', b'keep-alive'])
-            # (b'Connection', b'Close')
+            # Respect headers sent by client instead of manipulating
+            # Connection or Keep-Alive header.  However, note that per
+            # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection
+            # connection headers are meant for communication between client and
+            # first intercepting proxy.
             self.request.add_headers([(b'Via', b'1.1 proxy.py v%s' % version)])
-            # remove args.disable_headers before dispatching to upstream
+            # Disable args.disable_headers before dispatching to upstream
             self.server.queue(
                 self.request.build(
                     disable_headers=self.config.disable_headers))
@@ -1022,7 +1025,7 @@ class HttpProxyPlugin(HttpProtocolBasePlugin):
             logger.debug('Connected to upstream %s:%s' % (host, port))
         except Exception as e:  # TimeoutError, socket.gaierror
             self.server.closed = True
-            raise ProxyConnectionFailed(host, port, repr(e))
+            raise ProxyConnectionFailed(host, port, repr(e)) from e
 
 
 class HttpWebServerPlugin(HttpProtocolBasePlugin):

--- a/tests.py
+++ b/tests.py
@@ -1107,7 +1107,7 @@ class TestMain(unittest.TestCase):
         proxy.main(['--basic-auth', 'user:pass'])
         self.assertTrue(mock_set_open_file_limit.called)
         mock_multicore_dispatcher.assert_called_with(
-            hostname=proxy.DEFAULT_IPV4_HOSTNAME,
+            hostname=proxy.DEFAULT_IPV6_HOSTNAME,
             port=proxy.DEFAULT_PORT,
             ipv4=proxy.DEFAULT_IPV4,
             backlog=proxy.DEFAULT_BACKLOG,

--- a/tests.py
+++ b/tests.py
@@ -145,8 +145,9 @@ class TestTcpServer(unittest.TestCase):
                     socket.SOCK_STREAM,
                     0)
                 sock.connect(
-                    (proxy.DEFAULT_IPV4_HOSTNAME if ipv4 else proxy.DEFAULT_IPV6_HOSTNAME,
-                     self.ipv4_port if ipv4 else self.ipv6_port))
+                    (str(
+                        proxy.DEFAULT_IPV4_HOSTNAME if ipv4 else proxy.DEFAULT_IPV6_HOSTNAME),
+                        self.ipv4_port if ipv4 else self.ipv6_port))
                 sock.sendall(b'HELLO')
                 data = sock.recv(proxy.DEFAULT_BUFFER_SIZE)
                 self.assertEqual(data, b'WORLD')
@@ -209,7 +210,7 @@ class TestMultiCoreRequestDispatcher(unittest.TestCase):
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0) as sock:
                     try:
                         sock.connect(
-                            (proxy.DEFAULT_IPV4_HOSTNAME, self.tcp_port))
+                            (str(proxy.DEFAULT_IPV4_HOSTNAME), self.tcp_port))
                         sock.send(proxy.CRLF.join([
                             b'GET http://httpbin.org/get HTTP/1.1',
                             b'Host: httpbin.org',
@@ -975,7 +976,6 @@ class TestHttpProtocolHandler(unittest.TestCase):
             b'Host: localhost:%d' % self.http_server_port,
             b'Accept: */*',
             b'Via: %s' % b'1.1 proxy.py v%s' % proxy.version,
-            b'Connection: Close',
             proxy.CRLF
         ]))
 


### PR DESCRIPTION
Fixes #71 and #75 

- Previously, an IPv4 address like `--hostname 0.0.0.0` must be accompanied with `--ipv4` flag, since `proxy.py` now defaults to IPv6 addressing.  This is now fixed.
- Previously, `proxy.py` would explicitly add a `Connection: close` header when sending request to upstream.  This is no longer true and client header value is utilized as is.