### PR TITLE
Can serve proxy traffic over HTTPS

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,8 +29,8 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 proxy.py tests.py --count --exit-zero --max-line-length=127 --statistics
           # mypy compliance check
-          mypy --strict proxy.py
-          mypy tests.py
+          mypy --strict --ignore-missing-imports proxy.py
+          mypy --ignore-missing-imports tests.py
       - name: Run Tests
         run: |
           pytest tests.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .project
 .pydevproject
 .settings
-*.pyc
+.mypy_cache
 venv
 cover
 htmlcov
@@ -11,4 +11,5 @@ dist
 build
 proxy.py.egg-info
 proxy.py.iml
-.mypy_cache
+*.pyc
+*.pem

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Features
     - Enable plugin using command line option e.g. `--plugins plugin_examples.SaveHttpResponses`
     - Plugin API is currently in development state, expect breaking changes.
 - Secure
-    - Enable end-to-end encryption using TLS encryption
+    - Enable end-to-end encryption using TLS
     - See `--certfile` and `--keyfile` flags
 - Supported proxy protocols
     - `http`

--- a/README.md
+++ b/README.md
@@ -36,11 +36,19 @@ Features
     - Customize proxy and http routing via [plugins](https://github.com/abhinavsingh/proxy.py/blob/develop/plugin_examples.py)
     - Enable plugin using command line option e.g. `--plugins plugin_examples.SaveHttpResponses`
     - Plugin API is currently in development state, expect breaking changes.
-- Supports `http`, `https`, `http2` and `websockets` request proxy
+- Secure
+    - Can serve encrypted proxy traffic using `https`
+    - See `--certfile` and `--keyfile` flags
+- Supported proxy protocols
+    - `http`
+    - `https`
+    - `http2`
+    - `websockets`
 - Optimized for large file uploads and downloads
 - IPv4 and IPv6 support
 - Basic authentication support
 - Can serve a [PAC (Proxy Auto-configuration)](https://en.wikipedia.org/wiki/Proxy_auto-config) file
+    - See `--pac-file` and `--pac-file-url-path` flags
 
 Install
 -------
@@ -66,7 +74,6 @@ For example, to check `proxy.py --version`:
 
     $ docker run -it \
         -p 8899:8899 \
-        --entrypoint /app/proxy.py \
         --rm abhinavsingh/proxy.py:v1.0.0 \
         --version
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Features
     - Enable plugin using command line option e.g. `--plugins plugin_examples.SaveHttpResponses`
     - Plugin API is currently in development state, expect breaking changes.
 - Secure
-    - Can serve encrypted proxy traffic using `https`
+    - Enable end-to-end encryption using TLS encryption
     - See `--certfile` and `--keyfile` flags
 - Supported proxy protocols
     - `http`

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ optional arguments:
   --basic-auth BASIC_AUTH
                         Default: No authentication. Specify colon separated
                         user:password to enable basic authentication.
+  --certfile CERTFILE   Default: None. Server certificate. If used, you must
+                        also pass --keyfile.
   --client-recvbuf-size CLIENT_RECVBUF_SIZE
                         Default: 1 MB. Maximum amount of data received from
                         the client in a single recv() operation. Bump this
@@ -109,11 +111,11 @@ optional arguments:
                         server.
   --disable-http-proxy  Default: False. Whether to disable
                         proxy.HttpProxyPlugin.
-  --hostname HOSTNAME   Default: 127.0.0.1. Server IP address.
-  --ipv4                Whether to listen on IPv4 address. By default server
-                        only listens on IPv6.
+  --hostname HOSTNAME   Default: ::1. Server IP address.
   --enable-web-server   Default: False. Whether to enable
                         proxy.HttpWebServerPlugin.
+  --keyfile KEYFILE     Default: None. Server key file. If used, you must also
+                        pass --certfile.
   --log-level LOG_LEVEL
                         Valid options: DEBUG, INFO (default), WARNING, ERROR,
                         CRITICAL. Both upper and lowercase values are allowed.

--- a/proxy.py
+++ b/proxy.py
@@ -339,7 +339,7 @@ class HttpProtocolConfig:
                              ipaddress.IPv6Address] = hostname
         self.port: int = port
         self.backlog: int = backlog
-        self.family: socket.AddressFamily = socket.AF_INET6 if hostname.version == 6 else socket.AF_INET
+        self.family: socket.AddressFamily = socket.AF_INET if hostname.version == 4 else socket.AF_INET6
 
 
 class MultiCoreRequestDispatcher(TcpServer):

--- a/tests.py
+++ b/tests.py
@@ -1020,14 +1020,18 @@ class TestWorker(unittest.TestCase):
         self.worker.run()
         self.assertFalse(mock_http_proxy.called)
 
+    @mock.patch('socket.fromfd')
     @mock.patch('proxy.recv_handle')
     @mock.patch('proxy.HttpProtocolHandler')
     def test_spawns_http_proxy_threads(
-            self, mock_http_proxy, mock_recv_handle):
-        mock_recv_handle.return_value = 0
+            self, mock_http_proxy, mock_recv_handle, mock_fromfd):
+        fileno = 10
+        mock_recv_handle.return_value = fileno
         self.pipe[0].send((proxy.workerOperations.HTTP_PROTOCOL, None))
         self.pipe[0].send((proxy.workerOperations.SHUTDOWN, None))
         self.worker.run()
+        self.assertTrue(mock_fromfd.called)
+        mock_fromfd.assert_called_with(fileno, family=socket.AF_INET6, type=socket.SOCK_STREAM)
         self.assertTrue(mock_http_proxy.called)
 
 


### PR DESCRIPTION
Pass `--certfile` and `--keyfile` arguments to enable SSL/TLS layer. Example:

1) Start `proxy.py` as

`./proxy.py --certfile cert.pem --keyfile key.pem`

2) Then verify via `curl`

`curl -v -x https://localhost:8899 --proxy-cacert cert.pem http://httpbin.org/get`

3) Deprecates `--ipv4` flag.  Now auto-detected.