### PR TITLE
Add support for TLS/SSL interception and HTTPS server

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,6 +31,7 @@ jobs:
           # mypy compliance check
           mypy --strict --ignore-missing-imports proxy.py
           mypy --ignore-missing-imports tests.py
+          mypy --strict --ignore-missing-imports plugin_examples.py
       - name: Run Tests
         run: |
           pytest tests.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,9 +29,8 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 proxy.py tests.py --count --exit-zero --max-line-length=127 --statistics
           # mypy compliance check
-          mypy --strict --ignore-missing-imports proxy.py
+          mypy --strict --ignore-missing-imports proxy.py plugin_examples.py
           mypy --ignore-missing-imports tests.py
-          mypy --strict --ignore-missing-imports plugin_examples.py
       - name: Run Tests
         run: |
           pytest tests.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,4 @@ EXPOSE 8899/tcp
 WORKDIR /app
 ENTRYPOINT [ "./proxy.py" ]
 CMD [ "--hostname=0.0.0.0", \
-      "--port=8899", \
-      "--ipv4" ]
+      "--port=8899" ]

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ coverage:
 lint:
 	autopep8 --recursive --in-place --aggressive proxy.py
 	autopep8 --recursive --in-place --aggressive tests.py
+	autopep8 --recursive --in-place --aggressive plugin_examples.py
 	flake8 --ignore=E501,W504 --builtins="unicode" proxy.py
 	flake8 --ignore=E501,W504 tests.py
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ VERSION ?= v$(shell python proxy.py --version)
 LATEST_TAG := $(NS)/$(IMAGE_NAME):latest
 IMAGE_TAG := $(NS)/$(IMAGE_NAME):$(VERSION)
 
-.PHONY: all clean test package test-release release coverage lint container run-container release-container
+.PHONY: all clean test package test-release release coverage lint
+.PHONY: container run-container release-container server-cert
 
 all: clean test
 
@@ -49,3 +50,6 @@ run-container:
 
 release-container:
 	docker push $(IMAGE_TAG)
+
+server-cert:
+	openssl req -newkey rsa:2048 -nodes -keyout server-key.pem -x509 -days 365 -out server-cert.pem

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ Usage
 -----
 
 ```
+$ proxy.py -h
 usage: proxy.py [-h] [--backlog BACKLOG] [--basic-auth BASIC_AUTH]
-                [--ca-key-key CA_KEY_KEY] [--ca-cert-dir CA_CERT_DIR]
+                [--ca-key-file CA_KEY_FILE] [--ca-cert-dir CA_CERT_DIR]
                 [--ca-cert-file CA_CERT_FILE]
                 [--ca-signing-key-file CA_SIGNING_KEY_FILE]
                 [--cert-file CERT_FILE]
@@ -114,14 +115,14 @@ optional arguments:
   --basic-auth BASIC_AUTH
                         Default: No authentication. Specify colon separated
                         user:password to enable basic authentication.
-  --ca-key-key CA_KEY_KEY
+  --ca-key-file CA_KEY_FILE
                         Default: None. CA key to use for signing dynamically
                         generated HTTPS certificates. If used, must also pass
                         --ca-cert-file and --ca-signing-key-file
   --ca-cert-dir CA_CERT_DIR
                         Default: ~/.proxy.py. Directory to store dynamically
-                        generated certificates. If used, must also pass --ca-
-                        key-file, --ca-cert-file and --ca-signing-key-file
+                        generated certificates. Also see --ca-key-file, --ca-
+                        cert-file and --ca-signing-key-file
   --ca-cert-file CA_CERT_FILE
                         Default: None. Signing certificate to use for signing
                         dynamically generated HTTPS certificates. If used,

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Features
 - Programmable
     - Optionally enable builtin Web Server
     - Customize proxy and http routing via [plugins](https://github.com/abhinavsingh/proxy.py/blob/develop/plugin_examples.py)
-    - Enable plugin using command line option e.g. `--plugins plugin_examples.SaveHttpResponses`
+    - Enable plugin using command line option e.g. `--plugins plugin_examples.CacheHttpResponses`
     - Plugin API is currently in development state, expect breaking changes.
 - Secure
     - Enable end-to-end encryption between clients and `proxy.py` using TLS

--- a/README.md
+++ b/README.md
@@ -37,9 +37,13 @@ Features
     - Enable plugin using command line option e.g. `--plugins plugin_examples.SaveHttpResponses`
     - Plugin API is currently in development state, expect breaking changes.
 - Secure
-    - Enable end-to-end encryption using TLS
-    - See `--certfile` and `--keyfile` flags
-    - Run `make server-cert` to generate a self-signed certificated for testing
+    - Enable end-to-end encryption between clients and `proxy.py` using TLS
+    - See `--key-file` and `--cert-file` flags
+    - Generate self-signed certificates locally by running `make https-certificates`
+- Man-In-The-Middle
+    - Can decrypt TLS traffic between clients and upstream servers
+    - See `--ca-key-file`, `--ca-cert-key`, `--ca-signing-key`, `--ca-cert-dir` flags
+    - Generate CA certificates locally using `make ca-certificates`
 - Supported proxy protocols
     - `http`
     - `https`
@@ -85,13 +89,17 @@ Usage
 -----
 
 ```
-$ proxy.py -h
 usage: proxy.py [-h] [--backlog BACKLOG] [--basic-auth BASIC_AUTH]
+                [--ca-key-key CA_KEY_KEY] [--ca-cert-dir CA_CERT_DIR]
+                [--ca-cert-file CA_CERT_FILE]
+                [--ca-signing-key-file CA_SIGNING_KEY_FILE]
+                [--cert-file CERT_FILE]
                 [--client-recvbuf-size CLIENT_RECVBUF_SIZE]
                 [--disable-headers DISABLE_HEADERS] [--disable-http-proxy]
-                [--hostname HOSTNAME] [--ipv4] [--enable-web-server]
-                [--log-level LOG_LEVEL] [--log-file LOG_FILE]
-                [--log-format LOG_FORMAT] [--num-workers NUM_WORKERS]
+                [--enable-web-server] [--hostname HOSTNAME]
+                [--key-file KEY_FILE] [--log-level LOG_LEVEL]
+                [--log-file LOG_FILE] [--log-format LOG_FORMAT]
+                [--num-workers NUM_WORKERS]
                 [--open-file-limit OPEN_FILE_LIMIT] [--pac-file PAC_FILE]
                 [--pac-file-url-path PAC_FILE_URL_PATH] [--pid-file PID_FILE]
                 [--plugins PLUGINS] [--port PORT]
@@ -106,8 +114,26 @@ optional arguments:
   --basic-auth BASIC_AUTH
                         Default: No authentication. Specify colon separated
                         user:password to enable basic authentication.
-  --certfile CERTFILE   Default: None. Server certificate. If used, you must
-                        also pass --keyfile.
+  --ca-key-key CA_KEY_KEY
+                        Default: None. CA key to use for signing dynamically
+                        generated HTTPS certificates. If used, must also pass
+                        --ca-cert-file and --ca-signing-key-file
+  --ca-cert-dir CA_CERT_DIR
+                        Default: ~/.proxy.py. Directory to store dynamically
+                        generated certificates. If used, must also pass --ca-
+                        key-file, --ca-cert-file and --ca-signing-key-file
+  --ca-cert-file CA_CERT_FILE
+                        Default: None. Signing certificate to use for signing
+                        dynamically generated HTTPS certificates. If used,
+                        must also pass --ca-key-file and --ca-signing-key-file
+  --ca-signing-key-file CA_SIGNING_KEY_FILE
+                        Default: None. CA signing key to use for dynamic
+                        generation of HTTPS certificates. If used, must also
+                        pass --ca-key-file and --ca-cert-file
+  --cert-file CERT_FILE
+                        Default: None. Server certificate to enable end-to-end
+                        TLS encryption with clients. If used, must also pass
+                        --key-file.
   --client-recvbuf-size CLIENT_RECVBUF_SIZE
                         Default: 1 MB. Maximum amount of data received from
                         the client in a single recv() operation. Bump this
@@ -119,11 +145,12 @@ optional arguments:
                         server.
   --disable-http-proxy  Default: False. Whether to disable
                         proxy.HttpProxyPlugin.
-  --hostname HOSTNAME   Default: ::1. Server IP address.
   --enable-web-server   Default: False. Whether to enable
                         proxy.HttpWebServerPlugin.
-  --keyfile KEYFILE     Default: None. Server key file. If used, you must also
-                        pass --certfile.
+  --hostname HOSTNAME   Default: ::1. Server IP address.
+  --key-file KEY_FILE   Default: None. Server key file to enable end-to-end
+                        TLS encryption with clients. If used, must also pass
+                        --cert-file.
   --log-level LOG_LEVEL
                         Valid options: DEBUG, INFO (default), WARNING, ERROR,
                         CRITICAL. Both upper and lowercase values are allowed.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Features
 - Secure
     - Enable end-to-end encryption using TLS
     - See `--certfile` and `--keyfile` flags
+    - Run `make server-cert` to generate a self-signed certificated for testing
 - Supported proxy protocols
     - `http`
     - `https`

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Features
 - Programmable
     - Optionally enable builtin Web Server
     - Customize proxy and http routing via [plugins](https://github.com/abhinavsingh/proxy.py/blob/develop/plugin_examples.py)
-    - Enable plugin using command line option e.g. `--plugins plugin_examples.CacheHttpResponses`
+    - Enable plugin using command line option e.g. `--plugins plugin_examples.CacheResponsesPlugin`
     - Plugin API is currently in development state, expect breaking changes.
 - Secure
     - Enable end-to-end encryption between clients and `proxy.py` using TLS

--- a/plugin_examples.py
+++ b/plugin_examples.py
@@ -8,59 +8,60 @@
 """
 
 from urllib import parse as urlparse
+
 import proxy
 
 
 class RedirectToCustomServerPlugin(proxy.HttpProxyBasePlugin):
     """Modifies client request to redirect all incoming requests to a fixed server address."""
 
-    def __init__(self, config, client, request):
-        super(RedirectToCustomServerPlugin, self).__init__(config, client, request)
+    def __init__(self, config: proxy.HttpProtocolConfig, client: proxy.TcpClientConnection,
+                 request: proxy.HttpParser) -> None:
+        super().__init__(config, client, request)
 
-    def before_upstream_connection(self):
+    def before_upstream_connection(self) -> None:
+        # Redirect all non-https requests to inbuilt WebServer.
         if self.request.method != b'CONNECT':
-            # Redirect all non-https requests to inbuilt WebServer.
             self.request.url = urlparse.urlsplit(b'http://localhost:8899')
 
-    def on_upstream_connection(self):
+    def on_upstream_connection(self) -> None:
         pass
 
-    def handle_upstream_response(self, raw):
+    def handle_upstream_response(self, raw: bytes) -> bytes:
         return raw
 
 
 class FilterByTargetDomainPlugin(proxy.HttpProxyBasePlugin):
     """Only accepts specific requests dropping all other requests."""
 
-    def __init__(self, config, client, request):
-        super(FilterByTargetDomainPlugin, self).__init__(config, client, request)
+    def __init__(self, config: proxy.HttpProtocolConfig, client: proxy.TcpClientConnection,
+                 request: proxy.HttpParser) -> None:
+        super().__init__(config, client, request)
         self.filtered_domain = b'google.com'
 
-    def before_upstream_connection(self):
-        # TODO: Refactor internals to cleanup mess below, due to how urlparse works, hostname/path attributes
-        # are not consistent between CONNECT and non-CONNECT requests.
-        if (self.request.method != b'CONNECT' and self.filtered_domain in self.request.url.hostname) or \
-                (self.request.method == b'CONNECT' and self.filtered_domain in self.request.url.path):
+    def before_upstream_connection(self) -> None:
+        if self.filtered_domain == self.request.host:
             raise proxy.HttpRequestRejected(status_code=418, body=b'I\'m a tea pot')
 
-    def on_upstream_connection(self):
+    def on_upstream_connection(self) -> None:
         pass
 
-    def handle_upstream_response(self, raw):
+    def handle_upstream_response(self, raw: bytes) -> bytes:
         return raw
 
 
-class SaveHttpResponses(proxy.HttpProxyBasePlugin):
-    """Saves Http Responses locally on disk."""
+class CacheHttpResponses(proxy.HttpProxyBasePlugin):
+    """Caches Http Responses."""
 
-    def __init__(self, config, client, request):
-        super(SaveHttpResponses, self).__init__(config, client, request)
+    def __init__(self, config: proxy.HttpProtocolConfig, client: proxy.TcpClientConnection,
+                 request: proxy.HttpParser) -> None:
+        super().__init__(config, client, request)
 
-    def handle_upstream_response(self, chunk):
+    def before_upstream_connection(self) -> None:
+        pass
+
+    def on_upstream_connection(self) -> None:
+        pass
+
+    def handle_upstream_response(self, chunk: bytes) -> bytes:
         return chunk
-
-    def before_upstream_connection(self):
-        pass
-
-    def on_upstream_connection(self):
-        pass

--- a/plugin_examples.py
+++ b/plugin_examples.py
@@ -9,7 +9,7 @@
 import os
 import tempfile
 import time
-from typing import Optional
+from typing import Optional, BinaryIO
 from urllib import parse as urlparse
 
 import proxy
@@ -72,7 +72,7 @@ class CacheResponsesPlugin(proxy.HttpProxyBasePlugin):
                  request: proxy.HttpParser) -> None:
         super().__init__(config, client, request)
         self.cache_file_path: Optional[str] = None
-        self.cache_file = None
+        self.cache_file: Optional[BinaryIO] = None
 
     def before_upstream_connection(self) -> None:
         pass
@@ -84,11 +84,13 @@ class CacheResponsesPlugin(proxy.HttpProxyBasePlugin):
         self.cache_file = open(self.cache_file_path, "wb")
 
     def handle_upstream_response(self, chunk: bytes) -> bytes:
-        self.cache_file.write(chunk)
+        if self.cache_file:
+            self.cache_file.write(chunk)
         return chunk
 
     def on_upstream_connection_close(self) -> None:
-        self.cache_file.close()
+        if self.cache_file:
+            self.cache_file.close()
         proxy.logger.info('Cached response at %s', self.cache_file_path)
 
 

--- a/plugin_examples.py
+++ b/plugin_examples.py
@@ -6,7 +6,10 @@
     :copyright: (c) 2013-present by Abhinav Singh.
     :license: BSD, see LICENSE for more details.
 """
-
+import os
+import tempfile
+import time
+from typing import Optional
 from urllib import parse as urlparse
 
 import proxy
@@ -15,6 +18,8 @@ import proxy
 class RedirectToCustomServerPlugin(proxy.HttpProxyBasePlugin):
     """Modifies client request to redirect all incoming requests to a fixed server address."""
 
+    UPSTREAM_SERVER = b'http://localhost:8899'
+
     def __init__(self, config: proxy.HttpProtocolConfig, client: proxy.TcpClientConnection,
                  request: proxy.HttpParser) -> None:
         super().__init__(config, client, request)
@@ -22,7 +27,8 @@ class RedirectToCustomServerPlugin(proxy.HttpProxyBasePlugin):
     def before_upstream_connection(self) -> None:
         # Redirect all non-https requests to inbuilt WebServer.
         if self.request.method != b'CONNECT':
-            self.request.url = urlparse.urlsplit(b'http://localhost:8899')
+            self.request.url = urlparse.urlsplit(self.UPSTREAM_SERVER)
+            self.request.set_host_port()
 
     def on_upstream_connection(self) -> None:
         pass
@@ -30,18 +36,22 @@ class RedirectToCustomServerPlugin(proxy.HttpProxyBasePlugin):
     def handle_upstream_response(self, raw: bytes) -> bytes:
         return raw
 
+    def on_upstream_connection_close(self) -> None:
+        pass
 
-class FilterByTargetDomainPlugin(proxy.HttpProxyBasePlugin):
-    """Only accepts specific requests dropping all other requests."""
+
+class FilterByUpstreamHostPlugin(proxy.HttpProxyBasePlugin):
+    """Drop traffic by inspecting upstream domain name."""
+
+    FILTERED_DOMAINS = [b'google.com', b'www.google.com']
 
     def __init__(self, config: proxy.HttpProtocolConfig, client: proxy.TcpClientConnection,
                  request: proxy.HttpParser) -> None:
         super().__init__(config, client, request)
-        self.filtered_domain = b'google.com'
 
     def before_upstream_connection(self) -> None:
-        if self.filtered_domain == self.request.host:
-            raise proxy.HttpRequestRejected(status_code=418, body=b'I\'m a tea pot')
+        if self.request.host in self.FILTERED_DOMAINS:
+            raise proxy.HttpRequestRejected(status_code=418, reason=b'I\'m a tea pot')
 
     def on_upstream_connection(self) -> None:
         pass
@@ -49,19 +59,56 @@ class FilterByTargetDomainPlugin(proxy.HttpProxyBasePlugin):
     def handle_upstream_response(self, raw: bytes) -> bytes:
         return raw
 
+    def on_upstream_connection_close(self) -> None:
+        pass
 
-class CacheHttpResponses(proxy.HttpProxyBasePlugin):
-    """Caches Http Responses."""
+
+class CacheResponsesPlugin(proxy.HttpProxyBasePlugin):
+    """Caches Upstream Server Responses."""
+
+    CACHE_DIR = tempfile.gettempdir()
 
     def __init__(self, config: proxy.HttpProtocolConfig, client: proxy.TcpClientConnection,
                  request: proxy.HttpParser) -> None:
         super().__init__(config, client, request)
+        self.cache_file_path: Optional[str] = None
+        self.cache_file = None
 
     def before_upstream_connection(self) -> None:
         pass
 
     def on_upstream_connection(self) -> None:
-        pass
+        self.cache_file_path = os.path.join(
+            self.CACHE_DIR,
+            '%s-%s.txt' % (proxy.text_(self.request.host), str(time.time())))
+        self.cache_file = open(self.cache_file_path, "wb")
 
     def handle_upstream_response(self, chunk: bytes) -> bytes:
+        self.cache_file.write(chunk)
         return chunk
+
+    def on_upstream_connection_close(self) -> None:
+        self.cache_file.close()
+        proxy.logger.info('Cached response at %s', self.cache_file_path)
+
+
+class ManInTheMiddlePlugin(proxy.HttpProxyBasePlugin):
+    """Modifies outgoing response to clients."""
+
+    def before_upstream_connection(self) -> None:
+        pass
+
+    def on_upstream_connection(self) -> None:
+        pass
+
+    def handle_upstream_response(self, raw: bytes) -> bytes:
+        body = b'Hello from man in the middle'
+        response = proxy.CRLF.join([
+            b'HTTP/1.1 200 OK',
+            b'Content-Length: ' + proxy.bytes_(str(len(body))),
+            proxy.CRLF,
+        ]) + body
+        return response
+
+    def on_upstream_connection_close(self) -> None:
+        pass

--- a/proxy.py
+++ b/proxy.py
@@ -1345,9 +1345,8 @@ class HttpProtocolHandler(threading.Thread):
                             ProxyAuthenticationFailed.__name__, ProxyConnectionFailed.__name__,
                             HttpRequestRejected.__name__):
                         logger.exception('HttpProtocolException type raised', exc_info=e)
-                        response = HttpProtocolException(e).response(self.request)
+                        response = e.response(self.request)     # type: ignore
                         if response:
-                            logger.debug(response)
                             self.client.queue(response)
                             # But is client also ready for writes?
                             self.client.flush()

--- a/proxy.py
+++ b/proxy.py
@@ -422,10 +422,15 @@ class Worker(multiprocessing.Process):
                     conn = socket.fromfd(
                         fileno, family=self.config.family, type=socket.SOCK_STREAM)
                     if self.config.certfile and self.config.keyfile:
-                        conn = ssl.wrap_socket(conn,
-                                               server_side=True,
-                                               certfile=self.config.certfile,
-                                               keyfile=self.config.keyfile)
+                        try:
+                            conn = ssl.wrap_socket(conn,
+                                                   server_side=True,
+                                                   certfile=self.config.certfile,
+                                                   keyfile=self.config.keyfile)
+                        except OSError as e:
+                            logging.exception('OSError encountered while ssl wrapping the client socket', exc_info=e)
+                            conn.close()
+                            continue
                     proxy = HttpProtocolHandler(
                         TcpClientConnection(conn=conn, addr=payload),
                         config=self.config)

--- a/proxy.py
+++ b/proxy.py
@@ -1636,6 +1636,12 @@ def main(input_args: List[str]) -> None:
     if args.version:
         print(text_(version))
         sys.exit(0)
+    
+    # HTTPS interception currently not supported if proxy.py is running on HTTPS itself
+    if (args.cert_file and args.key_file) and \
+            (args.ca_key_file and args.ca_cert_file and args.ca_signing_key_file):
+        print('HTTPS interception not supported when proxy.py is serving over HTTPS')
+        sys.exit(0)
 
     try:
         setup_logger(args.log_file, args.log_level, args.log_format)

--- a/proxy.py
+++ b/proxy.py
@@ -1035,7 +1035,8 @@ class HttpProxyPlugin(HttpProtocolBasePlugin):
             # 3) Accept client connection
             # 4) Wrap client connection socket using generated certificate
             # 5) Send incoming encrypted traffic over to wrapped client connection
-            # 6) On server side, receive decrypted traffic and send to upstream server connection
+            # 6) On server side, receive decrypted traffic and send to upstream
+            # server connection
             pass
 
         if self.server and not self.server.closed:
@@ -1065,7 +1066,7 @@ class HttpProxyPlugin(HttpProtocolBasePlugin):
                          self.config.ca_key_file, '-set_serial', str(int(time.time() * 1000)), '-out', cert_file_path],
                         stdin=gen_cert.stdout,
                         stderr=subprocess.PIPE)
-                    _sign_cert_response = sign_cert.communicate(timeout=10)
+                    sign_cert.communicate(timeout=10)
                 return cert_file_path
         else:
             return None
@@ -1092,7 +1093,8 @@ class HttpProxyPlugin(HttpProtocolBasePlugin):
                 HttpProxyPlugin.PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT)
             # If interception is enabled, generate server certificates
             if self.config.ca_key_file and self.config.ca_cert_file and self.config.ca_signing_key_file:
-                # Flush client buffer before wrapping, but is client ready for writes?
+                # Flush client buffer before wrapping, but is client ready for
+                # writes?
                 self.client.flush()
                 generated_cert = self.generate_upstream_certificate()
                 if generated_cert:
@@ -1109,7 +1111,8 @@ class HttpProxyPlugin(HttpProtocolBasePlugin):
                         # Wrap our connection to upstream server connection
                         self.server.conn = ssl.wrap_socket(
                             self.server.conn, ssl_version=ssl.PROTOCOL_TLSv1_2)
-                        logger.info('Intercepting traffic using %s', generated_cert)
+                        logger.info(
+                            'Intercepting traffic using %s', generated_cert)
                         return self.client.conn
         # for general http requests, re-build request packet
         # and queue for the server with appropriate headers
@@ -1168,9 +1171,13 @@ class HttpProxyPlugin(HttpProtocolBasePlugin):
         if host and port:
             self.server = TcpServerConnection(text_(host), port)
             try:
-                logger.debug('Connecting to upstream %s:%s' % (text_(host), port))
+                logger.debug(
+                    'Connecting to upstream %s:%s' %
+                    (text_(host), port))
                 self.server.connect()
-                logger.debug('Connected to upstream %s:%s' % (text_(host), port))
+                logger.debug(
+                    'Connected to upstream %s:%s' %
+                    (text_(host), port))
             except Exception as e:  # TimeoutError, socket.gaierror
                 self.server.closed = True
                 raise ProxyConnectionFailed(text_(host), port, repr(e)) from e
@@ -1636,8 +1643,9 @@ def main(input_args: List[str]) -> None:
     if args.version:
         print(text_(version))
         sys.exit(0)
-    
-    # HTTPS interception currently not supported if proxy.py is running on HTTPS itself
+
+    # HTTPS interception currently not supported if proxy.py is running on
+    # HTTPS itself
     if (args.cert_file and args.key_file) and \
             (args.ca_key_file and args.ca_cert_file and args.ca_signing_key_file):
         print('HTTPS interception not supported when proxy.py is serving over HTTPS')

--- a/tests.py
+++ b/tests.py
@@ -803,8 +803,8 @@ class TestHttpProtocolHandler(unittest.TestCase):
             b'Host: unknown.domain',
             proxy.CRLF
         ]))
-        with self.assertRaises(proxy.ProxyConnectionFailed):
-            self.proxy.run_once()
+        self.proxy.run_once()
+        self.assertEqual(self.proxy.client.conn.received, proxy.ProxyConnectionFailed.RESPONSE_PKT)
 
     @mock.patch('select.select')
     def test_proxy_authentication_failed(self, mock_select):
@@ -822,8 +822,8 @@ class TestHttpProtocolHandler(unittest.TestCase):
             b'Host: abhinavsingh.com',
             proxy.CRLF
         ]))
-        with self.assertRaises(proxy.ProxyAuthenticationFailed):
-            self.proxy.run_once()
+        self.proxy.run_once()
+        self.assertEqual(self.proxy.client.conn.received, proxy.ProxyAuthenticationFailed.RESPONSE_PKT)
 
     @mock.patch('select.select')
     @mock.patch('proxy.TcpServerConnection')

--- a/tests.py
+++ b/tests.py
@@ -1140,6 +1140,10 @@ class TestMain(unittest.TestCase):
             num_workers=multiprocessing.cpu_count(),
             keyfile=None,
             certfile=None,
+            ca_cert_file=None,
+            ca_key_file=None,
+            ca_signing_key_file=None,
+            ca_cert_dir=None
         )
 
     @mock.patch('builtins.print')

--- a/tests.py
+++ b/tests.py
@@ -321,7 +321,8 @@ class TestHttpParser(unittest.TestCase):
 
     def test_find_line(self):
         self.assertEqual(
-            proxy.HttpParser.find_line(b'CONNECT python.org:443 HTTP/1.0\r\n\r\n'),
+            proxy.HttpParser.find_line(
+                b'CONNECT python.org:443 HTTP/1.0\r\n\r\n'),
             (b'CONNECT python.org:443 HTTP/1.0',
              b'\r\n'))
 
@@ -1031,7 +1032,8 @@ class TestWorker(unittest.TestCase):
         self.pipe[0].send((proxy.workerOperations.SHUTDOWN, None))
         self.worker.run()
         self.assertTrue(mock_fromfd.called)
-        mock_fromfd.assert_called_with(fileno, family=socket.AF_INET6, type=socket.SOCK_STREAM)
+        mock_fromfd.assert_called_with(
+            fileno, family=socket.AF_INET6, type=socket.SOCK_STREAM)
         self.assertTrue(mock_http_proxy.called)
 
 

--- a/tests.py
+++ b/tests.py
@@ -675,6 +675,9 @@ class MockTcpConnection:
     def close(self):
         self.closed = True
 
+    def shutdown(self, _how):
+        pass
+
 
 class HTTPRequestHandler(BaseHTTPRequestHandler):
 


### PR DESCRIPTION
- Fixes https://github.com/abhinavsingh/proxy.py/issues/84 and Fixes https://github.com/abhinavsingh/proxy.py/issues/87. To try, start `proxy.py` as:

    `proxy.py --ca-key-file ca-key.pem --ca-cert-file ca-cert.pem --ca-signing-key-file ca-signing-key.pem`

    Verifying using `curl`

    `curl -v -L -x proxy.py:8899 --cacert ca-cert.pem https://google.com`

- `proxy.py` can now communicate with clients using `https`. This is first step towards https://github.com/abhinavsingh/proxy.py/issues/79 (supporting `h2`).  To enable end-to-end encryption with client:

    `proxy.py --key-file https-key.pem --cert-file https-cert.pem`

