### PR TITLE
Add ProposedRestApiPlugin example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Table of Contents
     * [Command Line](#command-line)
     * [Docker Image](#docker-image)
 * [Plugin Examples](#plugin-examples)
+    * [ProposedRestApiPlugin](#proposedrestapiplugin)
     * [RedirectToCustomServerPlugin](#redirecttocustomserverplugin)
     * [FilterByUpstreamHostPlugin](#filterbyupstreamhostplugin)
     * [CacheResponsesPlugin](#cacheresponsesplugin)
@@ -166,6 +167,38 @@ See [plugin_examples.py](https://github.com/abhinavsingh/proxy.py/blob/develop/p
 
 All the examples below also works with `https` traffic but require additional flags and certificate generation. 
 See [TLS Interception](#tls-interception).
+
+## ProposedRestApiPlugin
+
+Mock responses for your server REST API.
+
+Use to test and develop client side applications
+without need of an actual upstream REST API server.
+
+Start `proxy.py` as:
+
+```
+$ proxy.py \
+    --plugins plugin_examples.ProposedRestApiPlugin
+```
+
+Verify mock API response using `curl -x localhost:8899 http://api.example.com/v1/users/`
+
+```
+{"count": 2, "next": null, "previous": null, "results": [{"email": "you@example.com", "groups": [], "url": "api.example.com/v1/users/1/", "username": "admin"}, {"email": "someone@example.com", "groups": [], "url": "api.example.com/v1/users/2/", "username": "admin"}]}
+```
+
+Verify the same by inspecting `proxy.py` logs:
+
+```
+2019-09-27 12:44:02,212 - INFO - pid:7077 - access_log:1210 - ::1:64792 - GET None:None/v1/users/ - None None - 0 byte
+```
+
+Access log shows `None:None` as server `ip:port`.  `None` simply means that
+the server connection was never made, since response was returned by our plugin.
+
+Now modify `ProposedRestApiPlugin` to returns REST API mock 
+responses as expected by your clients.
 
 ## RedirectToCustomServerPlugin
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ See [TLS Interception](#tls-interception).
 ## ProposedRestApiPlugin
 
 Mock responses for your server REST API.
-
 Use to test and develop client side applications
 without need of an actual upstream REST API server.
 

--- a/plugin_examples.py
+++ b/plugin_examples.py
@@ -6,6 +6,7 @@
     :copyright: (c) 2013-present by Abhinav Singh.
     :license: BSD, see LICENSE for more details.
 """
+import json
 import os
 import tempfile
 import time
@@ -17,7 +18,67 @@ import proxy
 
 @proxy.route(b'/hello-world')
 def hello_world(_request: proxy.HttpParser) -> bytes:
+    """A HttpWebServerRoutePlugin plugin for inbuilt web server."""
     return proxy.HttpParser.build_response(200, body=b'Hello World')
+
+
+class ProposedRestApiPlugin(proxy.HttpProxyBasePlugin):
+    """Mock responses for your upstream REST API.
+
+    Used to test and develop client side applications
+    without need of an actual upstream REST API server.
+
+    Returns proposed REST API mock responses to the client."""
+
+    API_SERVER = b'api.example.com'
+
+    REST_API_SPEC = {
+        b'/v1/users/': {
+            'count': 2,
+            'next': None,
+            'previous': None,
+            'results': [
+                {
+                    'email': 'you@example.com',
+                    'groups': [],
+                    'url': proxy.text_(API_SERVER) + '/v1/users/1/',
+                    'username': 'admin',
+                },
+                {
+                    'email': 'someone@example.com',
+                    'groups': [],
+                    'url': proxy.text_(API_SERVER) + '/v1/users/2/',
+                    'username': 'admin',
+                },
+            ]
+        }
+    }
+
+    def before_upstream_connection(self) -> bool:
+        """Called after client request is received and
+        before connecting to upstream server."""
+        if self.request.host == self.API_SERVER:
+            if self.request.url.path in self.REST_API_SPEC:
+                self.client.send(proxy.HttpParser.build_response(
+                    200, reason=b'OK',
+                    headers={b'Content-Type': b'application/json'},
+                    body=proxy.bytes_(json.dumps(self.REST_API_SPEC[self.request.url.path]))
+                ))
+            else:
+                self.client.send(proxy.HttpParser.build_response(
+                    404, reason=b'NOT FOUND', body=b'Not Found'
+                ))
+            return True
+        return False
+
+    def on_upstream_connection(self) -> None:
+        pass
+
+    def handle_upstream_response(self, raw: bytes) -> bytes:
+        return raw
+
+    def on_upstream_connection_close(self) -> None:
+        pass
 
 
 class RedirectToCustomServerPlugin(proxy.HttpProxyBasePlugin):
@@ -25,11 +86,12 @@ class RedirectToCustomServerPlugin(proxy.HttpProxyBasePlugin):
 
     UPSTREAM_SERVER = b'http://localhost:8899'
 
-    def before_upstream_connection(self) -> None:
+    def before_upstream_connection(self) -> bool:
         # Redirect all non-https requests to inbuilt WebServer.
         if self.request.method != b'CONNECT':
             self.request.url = urlparse.urlsplit(self.UPSTREAM_SERVER)
             self.request.set_host_port()
+        return False
 
     def on_upstream_connection(self) -> None:
         pass
@@ -46,10 +108,11 @@ class FilterByUpstreamHostPlugin(proxy.HttpProxyBasePlugin):
 
     FILTERED_DOMAINS = [b'google.com', b'www.google.com']
 
-    def before_upstream_connection(self) -> None:
+    def before_upstream_connection(self) -> bool:
         if self.request.host in self.FILTERED_DOMAINS:
             raise proxy.HttpRequestRejected(
                 status_code=418, reason=b'I\'m a tea pot')
+        return False
 
     def on_upstream_connection(self) -> None:
         pass
@@ -72,8 +135,8 @@ class CacheResponsesPlugin(proxy.HttpProxyBasePlugin):
         self.cache_file_path: Optional[str] = None
         self.cache_file: Optional[BinaryIO] = None
 
-    def before_upstream_connection(self) -> None:
-        pass
+    def before_upstream_connection(self) -> bool:
+        return False
 
     def on_upstream_connection(self) -> None:
         self.cache_file_path = os.path.join(
@@ -95,8 +158,8 @@ class CacheResponsesPlugin(proxy.HttpProxyBasePlugin):
 class ManInTheMiddlePlugin(proxy.HttpProxyBasePlugin):
     """Modifies upstream server responses."""
 
-    def before_upstream_connection(self) -> None:
-        pass
+    def before_upstream_connection(self) -> bool:
+        return False
 
     def on_upstream_connection(self) -> None:
         pass

--- a/plugin_examples.py
+++ b/plugin_examples.py
@@ -48,10 +48,10 @@ class ProposedRestApiPlugin(proxy.HttpProxyBasePlugin):
                     'email': 'someone@example.com',
                     'groups': [],
                     'url': proxy.text_(API_SERVER) + '/v1/users/2/',
-                    'username': 'admin',
+                    'username': 'someone',
                 },
             ]
-        }
+        },
     }
 
     def before_upstream_connection(self) -> bool:

--- a/plugin_examples.py
+++ b/plugin_examples.py
@@ -57,7 +57,7 @@ class ProposedRestApiPlugin(proxy.HttpProxyBasePlugin):
     def before_upstream_connection(self) -> bool:
         """Called after client request is received and
         before connecting to upstream server."""
-        if self.request.host == self.API_SERVER:
+        if self.request.host == self.API_SERVER and self.request.url:
             if self.request.url.path in self.REST_API_SPEC:
                 self.client.send(proxy.HttpParser.build_response(
                     200, reason=b'OK',


### PR DESCRIPTION
This plugin is an example to demonstrate how `proxy.py` can help you
test and debug client applications without actually having a need of
backend server.

Simply modify ProposedRestApiPlugin as per need to return json
responses for your API specs.