### PR TITLE
ssl.SSLError during handshake can teardown worker process

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -396,12 +396,23 @@ class Worker(multiprocessing.Process):
                 except BlockingIOError:  # as e:
                     # logger.exception('BlockingIOError', exc_info=e)
                     continue
-                work = self.work_klass(
-                    fileno=conn.fileno(),
-                    addr=addr,
-                    **self.kwargs)
-                work.setDaemon(True)
-                work.start()
+                try:
+                    work = self.work_klass(
+                        fileno=conn.fileno(),
+                        addr=addr,
+                        **self.kwargs)
+                    work.setDaemon(True)
+                    work.start()
+                except ssl.SSLError as e:
+                    logger.exception('ssl.SSLError', exc_info=e)
+                except Exception as e:
+                    logger.exception('Error encountered', exc_info=e)
+                finally:
+                    try:
+                        conn.shutdown(socket.SHUT_RDWR)
+                    except Exception as e:
+                        logger.exception('Error trying to shutdown client socket', exc_info=e)
+                    conn.close()
         except KeyboardInterrupt:
             pass
         finally:
@@ -1540,25 +1551,14 @@ class ProtocolHandler(threading.Thread):
         Shutdown and closes client connection upon error.
         """
         if self.config.certfile and self.config.keyfile:
-            try:
-                ctx = ssl.create_default_context(
-                    ssl.Purpose.CLIENT_AUTH)
-                ctx.options |= ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
-                ctx.verify_mode = ssl.CERT_NONE
-                ctx.load_cert_chain(
-                    certfile=self.config.certfile,
-                    keyfile=self.config.keyfile)
-                conn = ctx.wrap_socket(conn, server_side=True)
-                return conn
-            except Exception as e:
-                logger.exception('Error encountered', exc_info=e)
-                try:
-                    conn.shutdown(socket.SHUT_RDWR)
-                except Exception as e:
-                    logger.exception('Error trying to shutdown client socket', exc_info=e)
-                finally:
-                    conn.close()
-                return None
+            ctx = ssl.create_default_context(
+                ssl.Purpose.CLIENT_AUTH)
+            ctx.options |= ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+            ctx.verify_mode = ssl.CERT_NONE
+            ctx.load_cert_chain(
+                certfile=self.config.certfile,
+                keyfile=self.config.keyfile)
+            conn = ctx.wrap_socket(conn, server_side=True)
         return conn
 
     @staticmethod


### PR DESCRIPTION
prevent socket which is listening been close when TcpConnectionUninitializedException is raised