### PR TITLE
Invoke HttpWebServerBasePlugin.handle_request for each request in HTTP/1.1 pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Table of Contents
 * [Start proxy.py](#start-proxypy)
     * [Command Line](#command-line)
     * [Docker Image](#docker-image)
+        * [Stable version](#stable-version-from-docker-hub)
+        * [Development version](#build-development-version-locally)
 * [Plugin Examples](#plugin-examples)
     * [ProposedRestApiPlugin](#proposedrestapiplugin)
     * [RedirectToCustomServerPlugin](#redirecttocustomserverplugin)
@@ -66,7 +68,7 @@ Features
 ========
 
 - Lightweight
-    - Distributed as a single file module `~50KB`
+    - Distributed as a single file module `~100KB`
     - Uses only `~5-20MB` RAM
     - No external dependency other than standard Python library
 - Programmable
@@ -104,10 +106,11 @@ or from GitHub `master` branch
 
     $ pip install git+https://github.com/abhinavsingh/proxy.py.git@master
 
-or download from here [proxy.py](https://raw.githubusercontent.com/abhinavsingh/proxy.py/master/proxy.py)
 or simply `wget` it:
 
     $ wget -q https://raw.githubusercontent.com/abhinavsingh/proxy.py/master/proxy.py
+
+or download from here [proxy.py](https://raw.githubusercontent.com/abhinavsingh/proxy.py/master/proxy.py)
 
 ## Development version
 
@@ -166,19 +169,28 @@ See [flags](#flags) for full list of available configuration options.
 
 ## Docker image
 
+#### Stable Version from Docker Hub
+
     $ docker run -it -p 8899:8899 --rm abhinavsingh/proxy.py:latest
+
+#### Build Development Version Locally
+
+    $ git clone https://github.com/abhinavsingh/proxy.py.git
+    $ cd proxy.py
+    $ make container
+    $ docker run -it -p 8899:8899 --rm abhinavsingh/proxy.py:v$(./proxy.py -v)
 
 By default `docker` binary is started with IPv4 networking flags:
 
     --hostname 0.0.0.0 --port 8899
 
 To override input flags, start docker image as follows.
-For example, to check `proxy.py --version`:
+For example, to check `proxy.py` version within Docker image:
 
     $ docker run -it \
         -p 8899:8899 \
         --rm abhinavsingh/proxy.py:latest \
-        --version
+        -v
 
 [![WARNING](https://img.shields.io/static/v1?label=MacOS&message=warning&color=red)](https://github.com/moby/vpnkit/issues/469)
 `docker` image is currently broken on `macOS` due to incompatibility with [vpnkit](https://github.com/moby/vpnkit/issues/469).

--- a/plugin_examples.py
+++ b/plugin_examples.py
@@ -108,7 +108,9 @@ class RedirectToCustomServerPlugin(proxy.HttpProxyBasePlugin):
         # Redirect all non-https requests to inbuilt WebServer.
         if self.request.method != proxy.httpMethods.CONNECT:
             self.request.url = urlparse.urlsplit(self.UPSTREAM_SERVER)
-            self.request.set_host_port()
+            # This command will re-parse modified url and
+            # update host, port, path fields
+            self.request.set_line_attributes()
         return False
 
     def on_upstream_connection(self) -> None:
@@ -201,10 +203,9 @@ class WebServerPlugin(proxy.HttpWebServerBasePlugin):
         ]
 
     def handle_request(self, request: proxy.HttpParser) -> None:
-        path = request.build_url()
-        if path == b'/http-route-example':
+        if self.request.path == b'/http-route-example':
             self.client.queue(proxy.build_http_response(200, body=b'HTTP route response'))
-        elif path == b'/https-route-example':
+        elif self.request.path == b'/https-route-example':
             self.client.queue(proxy.build_http_response(200, body=b'HTTPS route response'))
 
     def on_websocket_open(self) -> None:

--- a/plugin_examples.py
+++ b/plugin_examples.py
@@ -203,9 +203,9 @@ class WebServerPlugin(proxy.HttpWebServerBasePlugin):
         ]
 
     def handle_request(self, request: proxy.HttpParser) -> None:
-        if self.request.path == b'/http-route-example':
+        if request.path == b'/http-route-example':
             self.client.queue(proxy.build_http_response(200, body=b'HTTP route response'))
-        elif self.request.path == b'/https-route-example':
+        elif request.path == b'/https-route-example':
             self.client.queue(proxy.build_http_response(200, body=b'HTTPS route response'))
 
     def on_websocket_open(self) -> None:

--- a/proxy.py
+++ b/proxy.py
@@ -1943,6 +1943,9 @@ class HttpWebServerPlugin(ProtocolHandlerPlugin):
             for r in self.routes[httpProtocolTypes.WEBSOCKET]:
                 if r == self.request.path:
                     self.routes[httpProtocolTypes.WEBSOCKET][r].on_websocket_close()
+        self.access_log()
+
+    def access_log(self) -> None:
         logger.info(
             '%s:%s - %s %s' %
             (self.client.addr[0], self.client.addr[1], text_(

--- a/proxy.py
+++ b/proxy.py
@@ -710,8 +710,8 @@ class HttpParser:
 
     def is_http_1_1_keep_alive(self) -> bool:
         return self.version == HTTP_1_1 and \
-               (not self.has_header(b'Connection') or
-                self.header(b'Connection').lower() == b'keep-alive')
+            (not self.has_header(b'Connection') or
+             self.header(b'Connection').lower() == b'keep-alive')
 
 
 class AcceptorPool:

--- a/proxy.py
+++ b/proxy.py
@@ -691,7 +691,7 @@ class HttpParser:
         return url
 
     def build(self, disable_headers: Optional[List[bytes]] = None) -> bytes:
-        assert self.method and self.version
+        assert self.method and self.version and self.path
         if disable_headers is None:
             disable_headers = DEFAULT_DISABLE_HEADERS
         body: Optional[bytes] = ChunkParser.to_chunks(self.body) \
@@ -1919,6 +1919,7 @@ class HttpWebServerPlugin(ProtocolHandlerPlugin):
                 self.pipeline_request = HttpParser(httpParserTypes.REQUEST_PARSER)
             self.pipeline_request.parse(raw)
             if self.pipeline_request.state == httpParserStates.COMPLETE:
+                assert self.route is not None
                 self.route.handle_request(self.pipeline_request)
                 self.pipeline_request = None
         return raw

--- a/tests.py
+++ b/tests.py
@@ -18,6 +18,7 @@ import socket
 import ssl
 import tempfile
 import unittest
+import uuid
 from contextlib import closing
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from threading import Thread
@@ -1551,20 +1552,23 @@ class TestHttpProxyTlsInterception(unittest.TestCase):
     @mock.patch('ssl.wrap_socket')
     @mock.patch('ssl.create_default_context')
     @mock.patch('proxy.TcpServerConnection')
-    @mock.patch('proxy.HttpProxyPlugin.generate_upstream_certificate')
+    @mock.patch('subprocess.Popen')
     @mock.patch('selectors.DefaultSelector')
     @mock.patch('socket.fromfd')
     def test_e2e(
             self,
             mock_fromfd: mock.Mock,
             mock_selector: mock.Mock,
-            mock_generate_certificate: mock.Mock,
+            mock_popen: mock.Mock,
             mock_server_conn: mock.Mock,
             mock_ssl_context: mock.Mock,
             mock_ssl_wrap: mock.Mock) -> None:
+        host, port = uuid.uuid4().hex, 443
+        netloc = '{0}:{1}'.format(host, port)
+
         self.mock_fromfd = mock_fromfd
         self.mock_selector = mock_selector
-        self.mock_generate_certificate = mock_generate_certificate
+        self.mock_popen = mock_popen
         self.mock_server_conn = mock_server_conn
         self.mock_ssl_context = mock_ssl_context
         self.mock_ssl_wrap = mock_ssl_wrap
@@ -1608,9 +1612,9 @@ class TestHttpProxyTlsInterception(unittest.TestCase):
         self.assertEqual(self.proxy_plugin.call_args[0][1].connection, self._conn)
 
         connect_request = proxy.build_http_request(
-            proxy.httpMethods.CONNECT, b'super.secure:443',
+            proxy.httpMethods.CONNECT, proxy.bytes_(netloc),
             headers={
-                b'Host': b'super.secure:443',
+                b'Host': proxy.bytes_(netloc),
             })
         self._conn.recv.return_value = connect_request
 
@@ -1643,7 +1647,7 @@ class TestHttpProxyTlsInterception(unittest.TestCase):
         self.proxy_plugin.return_value.before_upstream_connection.assert_called()
         self.proxy_plugin.return_value.on_upstream_connection.assert_called()
 
-        self.mock_server_conn.assert_called_with('super.secure', 443)
+        self.mock_server_conn.assert_called_with(host, port)
         self.mock_server_conn.return_value.connection.setblocking.assert_called_with(False)
 
         self.mock_ssl_context.assert_called_with(ssl.Purpose.SERVER_AUTH)
@@ -1651,26 +1655,27 @@ class TestHttpProxyTlsInterception(unittest.TestCase):
         #                  ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1)
         self.assertEqual(plain_connection.setblocking.call_count, 2)
         self.mock_ssl_context.return_value.wrap_socket.assert_called_with(
-            plain_connection, server_hostname='super.secure')
+            plain_connection, server_hostname=host)
+        # TODO: Assert Popen arguments, piping, success condition
+        self.assertEqual(self.mock_popen.call_count, 2)
         self.assertEqual(ssl_connection.setblocking.call_count, 1)
         self.assertEqual(self.mock_server_conn.return_value._conn, ssl_connection)
-        self.mock_generate_certificate.assert_called_with(
-            self.mock_server_conn.return_value.connection.getpeercert.return_value)
         self._conn.send.assert_called_with(proxy.HttpProxyPlugin.PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT)
+        assert self.config.ca_cert_dir is not None
         self.mock_ssl_wrap.assert_called_with(
             self._conn,
             server_side=True,
             keyfile=self.config.ca_signing_key_file,
-            certfile=self.mock_generate_certificate.return_value
+            certfile=proxy.HttpProxyPlugin.generated_cert_file_path(
+                self.config.ca_cert_dir, host)
         )
         self.assertEqual(self._conn.setblocking.call_count, 2)
         self.assertEqual(self.proxy.client.connection, self.mock_ssl_wrap.return_value)
 
         # Assert connection references for all other plugins is updated
         self.assertEqual(self.plugin.return_value.client._conn, self.mock_ssl_wrap.return_value)
-
-        # Currently proxy doesn't update it's own plugin
-        # self.assertEqual(self.proxy_plugin.return_value.client._conn, self._conn)
+        # Currently proxy doesn't update it's own plugin connection reference
+        # self.assertEqual(self.proxy_plugin.return_value.client._conn, self.mock_ssl_wrap.return_value)
 
 
 class TestHttpRequestRejected(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -543,7 +543,7 @@ class TestHttpParser(unittest.TestCase):
 
     def test_set_host_port_raises(self) -> None:
         with self.assertRaises(KeyError):
-            self.parser.set_host_port()
+            self.parser.set_line_attributes()
 
     def test_find_line(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
Example start with `WebServerPlugin` plugin:

```
./proxy.py \
    --enable-web-server \
    --plugins plugin_examples.WebServerPlugin
```

Send HTTP/1.1 pipeline request using `telnet`.  Our plugin.handle_request will now be invoked each time a new request completes on the pipelined connection.

```
$ telnet localhost 8899
Trying ::1...
Connected to localhost.
Escape character is '^]'.
GET http://localhost:8899/http-route-example HTTP/1.1

HTTP/1.1 200
Content-Length: 19

HTTP route responseGET http://localhost:8899/http-route-example HTTP/1.1

HTTP/1.1 200
Content-Length: 19

HTTP route responseGET http://localhost:8899/http-route-example HTTP/1.1

HTTP/1.1 200
Content-Length: 19

HTTP route responseGET http://localhost:8899/https-route-example HTTP/1.1   

HTTP/1.1 200
Content-Length: 20

HTTPS route response
```