### PR TITLE
Add --timeout flag with default value of 10 second.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ build
 proxy.py.egg-info
 proxy.py.iml
 *.pyc
-*.pem
+ca-*.pem
+https-*.pem
 benchmark.py

--- a/README.md
+++ b/README.md
@@ -995,7 +995,7 @@ optional arguments:
                         server root directory. This option is only applicable
                         when static server is also enabled. See --enable-
                         static-server.
-  --timeout TIMEOUT     Default: 5. Number of seconds after which an inactive
+  --timeout TIMEOUT     Default: 10. Number of seconds after which an inactive
                         connection must be dropped. Inactivity is defined by
                         no data sent or received by the client.
   --version, -v         Prints proxy.py version.

--- a/README.md
+++ b/README.md
@@ -905,9 +905,10 @@ usage: proxy.py [-h] [--backlog BACKLOG] [--basic-auth BASIC_AUTH]
                 [--pac-file-url-path PAC_FILE_URL_PATH] [--pid-file PID_FILE]
                 [--plugins PLUGINS] [--port PORT]
                 [--server-recvbuf-size SERVER_RECVBUF_SIZE]
-                [--static-server-dir STATIC_SERVER_DIR] [--version]
+                [--static-server-dir STATIC_SERVER_DIR] [--timeout TIMEOUT]
+                [--version]
 
-proxy.py v1.1.0
+proxy.py v1.2.0
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -994,6 +995,9 @@ optional arguments:
                         server root directory. This option is only applicable
                         when static server is also enabled. See --enable-
                         static-server.
+  --timeout TIMEOUT     Default: 5. Number of seconds after which an inactive
+                        connection must be dropped. Inactivity is defined by
+                        no data sent or received by the client.
   --version, -v         Prints proxy.py version.
 
 Proxy.py not working? Report at:

--- a/plugin_examples.py
+++ b/plugin_examples.py
@@ -81,14 +81,16 @@ class ProposedRestApiPlugin(proxy.HttpProxyBasePlugin):
         assert request.path
         if request.path in self.REST_API_SPEC:
             self.client.queue(proxy.build_http_response(
-                200, reason=b'OK',
+                proxy.httpStatusCodes.OK,
+                reason=b'OK',
                 headers={b'Content-Type': b'application/json'},
                 body=proxy.bytes_(json.dumps(
                     self.REST_API_SPEC[request.path]))
             ))
         else:
             self.client.queue(proxy.build_http_response(
-                404, reason=b'NOT FOUND', body=b'Not Found'
+                proxy.httpStatusCodes.NOT_FOUND,
+                reason=b'NOT FOUND', body=b'Not Found'
             ))
         return None
 
@@ -134,7 +136,7 @@ class FilterByUpstreamHostPlugin(proxy.HttpProxyBasePlugin):
     def before_upstream_connection(self, request: proxy.HttpParser) -> Optional[proxy.HttpParser]:
         if request.host in self.FILTERED_DOMAINS:
             raise proxy.HttpRequestRejected(
-                status_code=418, reason=b'I\'m a tea pot')
+                status_code=proxy.httpStatusCodes.I_AM_A_TEAPOT, reason=b'I\'m a tea pot')
         return request
 
     def handle_client_request(self, request: proxy.HttpParser) -> Optional[proxy.HttpParser]:
@@ -194,7 +196,8 @@ class ManInTheMiddlePlugin(proxy.HttpProxyBasePlugin):
 
     def handle_upstream_chunk(self, chunk: bytes) -> bytes:
         return proxy.build_http_response(
-            200, reason=b'OK', body=b'Hello from man in the middle')
+            proxy.httpStatusCodes.OK,
+            reason=b'OK', body=b'Hello from man in the middle')
 
     def on_upstream_connection_close(self) -> None:
         pass
@@ -212,9 +215,11 @@ class WebServerPlugin(proxy.HttpWebServerBasePlugin):
 
     def handle_request(self, request: proxy.HttpParser) -> None:
         if request.path == b'/http-route-example':
-            self.client.queue(proxy.build_http_response(200, body=b'HTTP route response'))
+            self.client.queue(proxy.build_http_response(
+                proxy.httpStatusCodes.OK, body=b'HTTP route response'))
         elif request.path == b'/https-route-example':
-            self.client.queue(proxy.build_http_response(200, body=b'HTTPS route response'))
+            self.client.queue(proxy.build_http_response(
+                proxy.httpStatusCodes.OK, body=b'HTTPS route response'))
 
     def on_websocket_open(self) -> None:
         proxy.logger.info('Websocket open')

--- a/proxy.py
+++ b/proxy.py
@@ -91,7 +91,7 @@ DEFAULT_STATIC_SERVER_DIR = os.path.join(PROXY_PY_DIR, 'public')
 DEFAULT_VERSION = False
 DEFAULT_LOG_FORMAT = '%(asctime)s - pid:%(process)d [%(levelname)-.1s] %(funcName)s:%(lineno)d - %(message)s'
 DEFAULT_LOG_FILE = None
-DEFAULT_TIMEOUT = 5
+DEFAULT_TIMEOUT = 10
 UNDER_TEST = False  # Set to True if under test
 
 logger = logging.getLogger(__name__)

--- a/proxy.py
+++ b/proxy.py
@@ -1164,7 +1164,7 @@ class HttpProxyBasePlugin(ABC):
         Raise HttpRequestRejected or ProtocolException directly to
             teardown the connection with client.
         """
-        return request
+        return request  # pragma: no cover
 
     @abstractmethod
     def handle_upstream_chunk(self, chunk: bytes) -> bytes:
@@ -1427,6 +1427,9 @@ class HttpProxyPlugin(ProtocolHandlerPlugin):
                 self.client.connection.setblocking(False)
                 logger.info(
                     'TLS interception using %s', generated_cert)
+                # Update all plugin connection reference
+                for plugin in self.plugins.values():
+                    plugin.client._conn = self.client.connection
                 return self.client.connection
         elif self.server:
             # - proxy-connection header is a mistake, it doesn't seem to be

--- a/tests.py
+++ b/tests.py
@@ -1761,6 +1761,7 @@ class TestMain(unittest.TestCase):
         mock_args.enable_devtools = proxy.DEFAULT_ENABLE_DEVTOOLS
         mock_args.devtools_event_queue = None
         mock_args.devtools_ws_path = proxy.DEFAULT_DEVTOOLS_WS_PATH
+        mock_args.timeout = proxy.DEFAULT_TIMEOUT
 
     @mock.patch('time.sleep')
     @mock.patch('proxy.load_plugins')
@@ -1817,6 +1818,7 @@ class TestMain(unittest.TestCase):
             enable_static_server=mock_args.enable_static_server,
             devtools_event_queue=None,
             devtools_ws_path=proxy.DEFAULT_DEVTOOLS_WS_PATH,
+            timeout=proxy.DEFAULT_TIMEOUT
         )
 
         mock_acceptor_pool.assert_called_with(

--- a/tests.py
+++ b/tests.py
@@ -1662,7 +1662,7 @@ class TestHttpProxyTlsInterception(unittest.TestCase):
                 data=None), selectors.EVENT_READ)], ]
         self.proxy.run_once()
 
-        # Assert our mocked plugin invocations
+        # Assert our mocked plugins invocations
         self.plugin.return_value.get_descriptors.assert_called()
         self.plugin.return_value.write_to_descriptors.assert_called_with([])
         self.plugin.return_value.on_client_data.assert_called_with(connect_request)
@@ -1698,8 +1698,7 @@ class TestHttpProxyTlsInterception(unittest.TestCase):
 
         # Assert connection references for all other plugins is updated
         self.assertEqual(self.plugin.return_value.client._conn, self.mock_ssl_wrap.return_value)
-        # Currently proxy doesn't update it's own plugin connection reference
-        # self.assertEqual(self.proxy_plugin.return_value.client._conn, self.mock_ssl_wrap.return_value)
+        self.assertEqual(self.proxy_plugin.return_value.client._conn, self.mock_ssl_wrap.return_value)
 
 
 class TestHttpRequestRejected(unittest.TestCase):


### PR DESCRIPTION
This value was previously hardcoded to `30 seconds` which I think was excessive.  If client and server are not exchanging data for more than `10 seconds`, drop the connection.

For `websocket` connections this can be a problem if they are not exchanging constant ping / pong data frames.  But then it already was a problem even with 30 seconds, just that problem will now trigger in 10 seconds instead of 30.