### PR TITLE
Move traffic_control outside of core plugin

### DIFF
--- a/dashboard/src/plugins/traffic_control.ts
+++ b/dashboard/src/plugins/traffic_control.ts
@@ -7,7 +7,7 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 */
-import { DashboardPlugin } from '../plugin'
+import { DashboardPlugin } from '../core/plugin'
 
 export class TrafficControlPlugin extends DashboardPlugin {
   public name: string = 'traffic_control'

--- a/dashboard/src/proxy.ts
+++ b/dashboard/src/proxy.ts
@@ -13,11 +13,11 @@ import { IDashboardPlugin, IPluginConstructor } from './core/plugin'
 
 import { HomePlugin } from './core/plugins/home'
 import { InspectTrafficPlugin } from './core/plugins/inspect_traffic'
-import { TrafficControlPlugin } from './core/plugins/traffic_control'
 import { SettingsPlugin } from './core/plugins/settings'
 
 import { MockRestApiPlugin } from './plugins/mock_rest_api'
 import { ShortlinkPlugin } from './plugins/shortlink'
+import { TrafficControlPlugin } from './plugins/traffic_control'
 
 export class ProxyDashboard {
   private static plugins: IPluginConstructor[] = [];


### PR DESCRIPTION
It maps to several plugin examples like redirectToUpstreamHost and filterByUpstreamHost