### PR TITLE
Introduce sendMessage websocket api which allows for callbacks

### DIFF
--- a/dashboard/src/core/plugins/inspect_traffic.ts
+++ b/dashboard/src/core/plugins/inspect_traffic.ts
@@ -21,10 +21,14 @@ export class InspectTrafficPlugin extends DashboardPlugin {
   }
 
   public activated (): void {
-    this.websocketApi.enableInspection()
+    this.websocketApi.enableInspection(this.handleEvents.bind(this))
   }
 
   public deactivated (): void {
     this.websocketApi.disableInspection()
+  }
+
+  public handleEvents (message: Record<string, any>): void {
+    console.log(message)
   }
 }

--- a/dashboard/src/proxy.ts
+++ b/dashboard/src/proxy.ts
@@ -23,7 +23,7 @@ export class ProxyDashboard {
   private static plugins: IPluginConstructor[] = [];
   private plugins: Map<string, IDashboardPlugin> = new Map();
 
-  private websocketApi: WebsocketApi
+  private readonly websocketApi: WebsocketApi
 
   constructor () {
     this.websocketApi = new WebsocketApi()


### PR DESCRIPTION
- Deprecate `lastPingId` and use callbacks instead