### PR TITLE
Make connection queue / recv work with memoryview to avoid copies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ autopep8:
 	autopep8 --recursive --in-place --aggressive proxy/*.py
 	autopep8 --recursive --in-place --aggressive proxy/*/*.py
 	autopep8 --recursive --in-place --aggressive tests/*.py
+	autopep8 --recursive --in-place --aggressive tests/*/*.py
 	autopep8 --recursive --in-place --aggressive setup.py
 
 https-certificates:

--- a/proxy/common/utils.py
+++ b/proxy/common/utils.py
@@ -120,20 +120,20 @@ def build_websocket_handshake_request(
     )
 
 
-def build_websocket_handshake_response(accept: bytes) -> bytes:
+def build_websocket_handshake_response(accept: bytes) -> memoryview:
     """
     Build and returns a Websocket handshake response packet.
 
     :param accept: Sec-WebSocket-Accept header value
     """
-    return build_http_response(
+    return memoryview(build_http_response(
         101, reason=b'Switching Protocols',
         headers={
             b'Upgrade': b'websocket',
             b'Connection': b'Upgrade',
             b'Sec-WebSocket-Accept': accept
         }
-    )
+    ))
 
 
 def find_http_line(raw: bytes) -> Tuple[Optional[bytes], bytes]:

--- a/proxy/common/utils.py
+++ b/proxy/common/utils.py
@@ -120,20 +120,20 @@ def build_websocket_handshake_request(
     )
 
 
-def build_websocket_handshake_response(accept: bytes) -> memoryview:
+def build_websocket_handshake_response(accept: bytes) -> bytes:
     """
     Build and returns a Websocket handshake response packet.
 
     :param accept: Sec-WebSocket-Accept header value
     """
-    return memoryview(build_http_response(
+    return build_http_response(
         101, reason=b'Switching Protocols',
         headers={
             b'Upgrade': b'websocket',
             b'Connection': b'Upgrade',
             b'Sec-WebSocket-Accept': accept
         }
-    ))
+    )
 
 
 def find_http_line(raw: bytes) -> Tuple[Optional[bytes], bytes]:

--- a/proxy/core/connection.py
+++ b/proxy/core/connection.py
@@ -55,7 +55,7 @@ class TcpConnection(ABC):
         """Users must handle BrokenPipeError exceptions"""
         return self.connection.send(data)
 
-    def recv(self, buffer_size: int = DEFAULT_BUFFER_SIZE) -> Optional[bytes]:
+    def recv(self, buffer_size: int = DEFAULT_BUFFER_SIZE) -> Optional[memoryview]:
         """Users must handle socket.error exceptions"""
         data: bytes = self.connection.recv(buffer_size)
         if len(data) == 0:
@@ -64,7 +64,7 @@ class TcpConnection(ABC):
             'received %d bytes from %s' %
             (len(data), self.tag))
         # logger.info(data)
-        return data
+        return memoryview(data)
 
     def close(self) -> bool:
         if not self.closed:

--- a/proxy/core/connection.py
+++ b/proxy/core/connection.py
@@ -55,7 +55,8 @@ class TcpConnection(ABC):
         """Users must handle BrokenPipeError exceptions"""
         return self.connection.send(data)
 
-    def recv(self, buffer_size: int = DEFAULT_BUFFER_SIZE) -> Optional[memoryview]:
+    def recv(
+            self, buffer_size: int = DEFAULT_BUFFER_SIZE) -> Optional[memoryview]:
         """Users must handle socket.error exceptions"""
         data: bytes = self.connection.recv(buffer_size)
         if len(data) == 0:

--- a/proxy/core/event.py
+++ b/proxy/core/event.py
@@ -184,7 +184,9 @@ class EventSubscriber:
         self.relay_thread.start()
         self.relay_sub_id = uuid.uuid4().hex
         self.event_queue.subscribe(self.relay_sub_id, self.relay_channel)
-        logger.debug('Subscribed relay sub id %s from core events', self.relay_sub_id)
+        logger.debug(
+            'Subscribed relay sub id %s from core events',
+            self.relay_sub_id)
 
     def unsubscribe(self) -> None:
         if self.relay_sub_id is None:
@@ -199,7 +201,9 @@ class EventSubscriber:
         self.event_queue.unsubscribe(self.relay_sub_id)
         self.relay_shutdown.set()
         self.relay_thread.join()
-        logger.debug('Un-subscribed relay sub id %s from core events', self.relay_sub_id)
+        logger.debug(
+            'Un-subscribed relay sub id %s from core events',
+            self.relay_sub_id)
 
         self.relay_thread = None
         self.relay_shutdown = None

--- a/proxy/dashboard/dashboard.py
+++ b/proxy/dashboard/dashboard.py
@@ -67,14 +67,14 @@ class ProxyDashboard(HttpWebServerBasePlugin):
         elif request.path in (
                 b'/dashboard',
                 b'/dashboard/proxy.html'):
-            self.client.queue(build_http_response(
+            self.client.queue(memoryview(build_http_response(
                 httpStatusCodes.PERMANENT_REDIRECT, reason=b'Permanent Redirect',
                 headers={
                     b'Location': b'/dashboard/',
                     b'Content-Length': b'0',
                     b'Connection': b'close',
                 }
-            ))
+            )))
 
     def on_websocket_open(self) -> None:
         logger.info('app ws opened')
@@ -104,6 +104,6 @@ class ProxyDashboard(HttpWebServerBasePlugin):
 
     def reply(self, data: Dict[str, Any]) -> None:
         self.client.queue(
-            WebsocketFrame.text(
+            memoryview(WebsocketFrame.text(
                 bytes_(
-                    json.dumps(data))))
+                    json.dumps(data)))))

--- a/proxy/dashboard/inspect_traffic.py
+++ b/proxy/dashboard/inspect_traffic.py
@@ -37,12 +37,12 @@ class InspectTrafficPlugin(ProxyDashboardWebsocketPlugin):
             # inspection can only be enabled if --enable-events is used
             if not self.flags.enable_events:
                 self.client.queue(
-                    WebsocketFrame.text(
+                    memoryview(WebsocketFrame.text(
                         bytes_(
                             json.dumps(
                                 {'id': message['id'], 'response': 'not enabled'})
                         )
-                    )
+                    ))
                 )
             else:
                 self.subscriber.subscribe(
@@ -61,6 +61,6 @@ class InspectTrafficPlugin(ProxyDashboardWebsocketPlugin):
     def callback(client: TcpClientConnection, event: Dict[str, Any]) -> None:
         event['push'] = 'inspect_traffic'
         client.queue(
-            WebsocketFrame.text(
+            memoryview(WebsocketFrame.text(
                 bytes_(
-                    json.dumps(event))))
+                    json.dumps(event)))))

--- a/proxy/dashboard/plugin.py
+++ b/proxy/dashboard/plugin.py
@@ -51,6 +51,6 @@ class ProxyDashboardWebsocketPlugin(ABC):
 
     def reply(self, data: Dict[str, Any]) -> None:
         self.client.queue(
-            WebsocketFrame.text(
+            memoryview(WebsocketFrame.text(
                 bytes_(
-                    json.dumps(data))))
+                    json.dumps(data)))))

--- a/proxy/http/handler.py
+++ b/proxy/http/handler.py
@@ -96,7 +96,7 @@ class HttpProtocolHandlerPlugin(ABC):
         return False  # pragma: no cover
 
     @abstractmethod
-    def on_response_chunk(self, chunk: bytes) -> bytes:
+    def on_response_chunk(self, chunk: List[memoryview]) -> List[memoryview]:
         """Handle data chunks as received from the server.
 
         Return optionally modified chunk to return back to client."""
@@ -215,8 +215,8 @@ class HttpProtocolHandler(ThreadlessWork):
 
             logger.debug(
                 'Closing client connection %r '
-                'at address %r with pending client buffer size %d bytes' %
-                (self.client.connection, self.client.addr, self.client.buffer_size()))
+                'at address %r has buffer %s' %
+                (self.client.connection, self.client.addr, self.client.has_buffer()))
 
             conn = self.client.connection
             # Unwrap if wrapped before shutdown.
@@ -281,10 +281,12 @@ class HttpProtocolHandler(ThreadlessWork):
             self.selector.unregister(self.client.connection)
 
     def handle_writables(self, writables: List[Union[int, HasFileno]]) -> bool:
-        if self.client.buffer_size() > 0 and self.client.connection in writables:
+        if self.client.has_buffer() and self.client.connection in writables:
             logger.debug('Client is ready for writes, flushing buffer')
             self.last_activity = time.time()
 
+            # TODO(abhinavsingh): This hook could just reside within server recv block
+            # instead of invoking when flushed to client.
             # Invoke plugin.on_response_chunk
             chunk = self.client.buffer
             for plugin in self.plugins.values():

--- a/proxy/http/handler.py
+++ b/proxy/http/handler.py
@@ -348,7 +348,8 @@ class HttpProtocolHandler(ThreadlessWork):
                 # valid request.
                 if client_data and self.request.state != httpParserStates.COMPLETE:
                     # Parse http request
-                    # TODO(abhinavsingh): Remove .tobytes after parser is memoryview compliant
+                    # TODO(abhinavsingh): Remove .tobytes after parser is
+                    # memoryview compliant
                     self.request.parse(client_data.tobytes())
                     if self.request.state == httpParserStates.COMPLETE:
                         # Invoke plugin.on_request_complete

--- a/proxy/http/inspector.py
+++ b/proxy/http/inspector.py
@@ -112,7 +112,7 @@ class DevtoolsProtocolPlugin(HttpWebServerBasePlugin):
 
         data['id'] = message['id']
         frame.data = bytes_(json.dumps(data))
-        self.client.queue(frame.build())
+        self.client.queue(memoryview(frame.build()))
 
 
 class CoreEventsToDevtoolsProtocol:
@@ -136,9 +136,9 @@ class CoreEventsToDevtoolsProtocol:
             # drop core events unrelated to Devtools
             return
         client.queue(
-            WebsocketFrame.text(
+            memoryview(WebsocketFrame.text(
                 bytes_(
-                    json.dumps(data))))
+                    json.dumps(data)))))
 
     @staticmethod
     def request_complete(event: Dict[str, Any]) -> Dict[str, Any]:

--- a/proxy/http/parser.py
+++ b/proxy/http/parser.py
@@ -117,7 +117,9 @@ class HttpParser:
                 self.host, self.port = self.url.hostname, self.url.port \
                     if self.url.port else 80
             else:
-                raise KeyError('Invalid request. Method: %r, Url: %r' % (self.method, self.url))
+                raise KeyError(
+                    'Invalid request. Method: %r, Url: %r' %
+                    (self.method, self.url))
             self.path = self.build_url()
 
     def is_chunked_encoded(self) -> bool:

--- a/proxy/http/proxy.py
+++ b/proxy/http/proxy.py
@@ -200,7 +200,8 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                 if self.response.state == httpParserStates.COMPLETE:
                     self.handle_pipeline_response(raw)
                 else:
-                    # TODO(abhinavsingh): Remove .tobytes after parser is memoryview compliant
+                    # TODO(abhinavsingh): Remove .tobytes after parser is
+                    # memoryview compliant
                     self.response.parse(raw.tobytes())
                     self.emit_response_events()
             else:
@@ -262,7 +263,8 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                 if self.pipeline_request is None:
                     self.pipeline_request = HttpParser(
                         httpParserTypes.REQUEST_PARSER)
-                # TODO(abhinavsingh): Remove .tobytes after parser is memoryview compliant
+                # TODO(abhinavsingh): Remove .tobytes after parser is
+                # memoryview compliant
                 self.pipeline_request.parse(raw.tobytes())
                 if self.pipeline_request.state == httpParserStates.COMPLETE:
                     for plugin in self.plugins.values():
@@ -272,8 +274,11 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                             return None
                         self.pipeline_request = r
                     assert self.pipeline_request is not None
-                    # TODO(abhinavsingh): Remove memoryview wrapping here after parser is fully memoryview compliant
-                    self.server.queue(memoryview(self.pipeline_request.build()))
+                    # TODO(abhinavsingh): Remove memoryview wrapping here after
+                    # parser is fully memoryview compliant
+                    self.server.queue(
+                        memoryview(
+                            self.pipeline_request.build()))
                     self.pipeline_request = None
             else:
                 self.server.queue(raw)
@@ -358,7 +363,8 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
         if self.pipeline_response is None:
             self.pipeline_response = HttpParser(
                 httpParserTypes.RESPONSE_PARSER)
-        # TODO(abhinavsingh): Remove .tobytes after parser is memoryview compliant
+        # TODO(abhinavsingh): Remove .tobytes after parser is memoryview
+        # compliant
         self.pipeline_response.parse(raw.tobytes())
         if self.pipeline_response.state == httpParserStates.COMPLETE:
             self.pipeline_response = None

--- a/proxy/http/server.py
+++ b/proxy/http/server.py
@@ -85,7 +85,7 @@ class HttpWebServerPacFilePlugin(HttpWebServerBasePlugin):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.pac_file_response: Optional[bytes] = None
+        self.pac_file_response: Optional[memoryview] = None
         self.cache_pac_file_response()
 
     def routes(self) -> List[Tuple[int, bytes]]:
@@ -116,30 +116,30 @@ class HttpWebServerPacFilePlugin(HttpWebServerBasePlugin):
                     content = f.read()
             except IOError:
                 content = bytes_(self.flags.pac_file)
-            self.pac_file_response = build_http_response(
+            self.pac_file_response = memoryview(build_http_response(
                 200, reason=b'OK', headers={
                     b'Content-Type': b'application/x-ns-proxy-autoconfig',
                     b'Content-Encoding': b'gzip',
                 }, body=gzip.compress(content)
-            )
+            ))
 
 
 class HttpWebServerPlugin(HttpProtocolHandlerPlugin):
     """HttpProtocolHandler plugin which handles incoming requests to local web server."""
 
-    DEFAULT_404_RESPONSE = build_http_response(
+    DEFAULT_404_RESPONSE = memoryview(build_http_response(
         httpStatusCodes.NOT_FOUND,
         reason=b'NOT FOUND',
         headers={b'Server': PROXY_AGENT_HEADER_VALUE,
                  b'Connection': b'close'}
-    )
+    ))
 
-    DEFAULT_501_RESPONSE = build_http_response(
+    DEFAULT_501_RESPONSE = memoryview(build_http_response(
         httpStatusCodes.NOT_IMPLEMENTED,
         reason=b'NOT IMPLEMENTED',
         headers={b'Server': PROXY_AGENT_HEADER_VALUE,
                  b'Connection': b'close'}
-    )
+    ))
 
     def __init__(
             self,
@@ -166,13 +166,13 @@ class HttpWebServerPlugin(HttpProtocolHandlerPlugin):
                     self.routes[protocol][path] = instance
 
     @staticmethod
-    def read_and_build_static_file_response(path: str) -> bytes:
+    def read_and_build_static_file_response(path: str) -> memoryview:
         with open(path, 'rb') as f:
             content = f.read()
         content_type = mimetypes.guess_type(path)[0]
         if content_type is None:
             content_type = 'text/plain'
-        return build_http_response(
+        return memoryview(build_http_response(
             httpStatusCodes.OK,
             reason=b'OK',
             headers={
@@ -181,7 +181,7 @@ class HttpWebServerPlugin(HttpProtocolHandlerPlugin):
                 b'Content-Encoding': b'gzip',
                 b'Connection': b'close',
             },
-            body=gzip.compress(content))
+            body=gzip.compress(content)))
 
     def serve_file_or_404(self, path: str) -> bool:
         """Read and serves a file from disk.
@@ -295,7 +295,7 @@ class HttpWebServerPlugin(HttpProtocolHandlerPlugin):
                 self.pipeline_request = None
         return raw
 
-    def on_response_chunk(self, chunk: bytes) -> bytes:
+    def on_response_chunk(self, chunk: List[memoryview]) -> List[memoryview]:
         return chunk
 
     def on_client_connection_close(self) -> None:

--- a/proxy/http/server.py
+++ b/proxy/http/server.py
@@ -202,9 +202,9 @@ class HttpWebServerPlugin(HttpProtocolHandlerPlugin):
             if self.request.has_header(b'upgrade') and \
                     self.request.header(b'upgrade').lower() == b'websocket':
                 self.client.queue(
-                    build_websocket_handshake_response(
+                    memoryview(build_websocket_handshake_response(
                         WebsocketFrame.key_to_accept(
-                            self.request.header(b'Sec-WebSocket-Key'))))
+                            self.request.header(b'Sec-WebSocket-Key')))))
                 self.switched_protocol = httpProtocolTypes.WEBSOCKET
             else:
                 self.client.queue(self.DEFAULT_501_RESPONSE)

--- a/proxy/http/server.py
+++ b/proxy/http/server.py
@@ -259,7 +259,8 @@ class HttpWebServerPlugin(HttpProtocolHandlerPlugin):
 
     def on_client_data(self, raw: memoryview) -> Optional[memoryview]:
         if self.switched_protocol == httpProtocolTypes.WEBSOCKET:
-            # TODO(abhinavsingh): Remove .tobytes after websocket frame parser is memoryview compliant
+            # TODO(abhinavsingh): Remove .tobytes after websocket frame parser
+            # is memoryview compliant
             remaining = raw.tobytes()
             frame = WebsocketFrame()
             while remaining != b'':
@@ -284,7 +285,8 @@ class HttpWebServerPlugin(HttpProtocolHandlerPlugin):
             if self.pipeline_request is None:
                 self.pipeline_request = HttpParser(
                     httpParserTypes.REQUEST_PARSER)
-            # TODO(abhinavsingh): Remove .tobytes after parser is memoryview compliant
+            # TODO(abhinavsingh): Remove .tobytes after parser is memoryview
+            # compliant
             self.pipeline_request.parse(raw.tobytes())
             if self.pipeline_request.state == httpParserStates.COMPLETE:
                 self.route.handle_request(self.pipeline_request)

--- a/proxy/http/websocket.py
+++ b/proxy/http/websocket.py
@@ -234,12 +234,13 @@ class WebsocketClient(TcpConnection):
         for key, mask in events:
             if mask & selectors.EVENT_READ and self.on_message:
                 raw = self.recv()
-                if raw is None or raw == b'':
+                if raw is None or raw.tobytes() == b'':
                     self.closed = True
                     logger.debug('Websocket connection closed by server')
                     return True
                 frame = WebsocketFrame()
-                frame.parse(raw)
+                # TODO(abhinavsingh): Remove .tobytes after parser is memoryview compliant
+                frame.parse(raw.tobytes())
                 self.on_message(frame)
             elif mask & selectors.EVENT_WRITE:
                 logger.debug(self.buffer)

--- a/proxy/http/websocket.py
+++ b/proxy/http/websocket.py
@@ -239,7 +239,8 @@ class WebsocketClient(TcpConnection):
                     logger.debug('Websocket connection closed by server')
                     return True
                 frame = WebsocketFrame()
-                # TODO(abhinavsingh): Remove .tobytes after parser is memoryview compliant
+                # TODO(abhinavsingh): Remove .tobytes after parser is
+                # memoryview compliant
                 frame.parse(raw.tobytes())
                 self.on_message(frame)
             elif mask & selectors.EVENT_WRITE:

--- a/proxy/plugin/cache/base.py
+++ b/proxy/plugin/cache/base.py
@@ -50,7 +50,7 @@ class BaseCacheResponsesPlugin(HttpProxyBasePlugin):
         assert self.store
         return self.store.cache_request(request)
 
-    def handle_upstream_chunk(self, chunk: bytes) -> bytes:
+    def handle_upstream_chunk(self, chunk: memoryview) -> memoryview:
         assert self.store
         return self.store.cache_response_chunk(chunk)
 

--- a/proxy/plugin/cache/store/base.py
+++ b/proxy/plugin/cache/store/base.py
@@ -28,7 +28,7 @@ class CacheStore(ABC):
         return request
 
     @abstractmethod
-    def cache_response_chunk(self, chunk: bytes) -> bytes:
+    def cache_response_chunk(self, chunk: memoryview) -> memoryview:
         return chunk
 
     @abstractmethod

--- a/proxy/plugin/cache/store/disk.py
+++ b/proxy/plugin/cache/store/disk.py
@@ -37,9 +37,9 @@ class OnDiskCacheStore(CacheStore):
     def cache_request(self, request: HttpParser) -> Optional[HttpParser]:
         return request
 
-    def cache_response_chunk(self, chunk: bytes) -> bytes:
+    def cache_response_chunk(self, chunk: memoryview) -> memoryview:
         if self.cache_file:
-            self.cache_file.write(chunk)
+            self.cache_file.write(chunk.tobytes())
         return chunk
 
     def close(self) -> None:

--- a/proxy/plugin/filter_by_upstream.py
+++ b/proxy/plugin/filter_by_upstream.py
@@ -36,7 +36,7 @@ class FilterByUpstreamHostPlugin(HttpProxyBasePlugin):
             self, request: HttpParser) -> Optional[HttpParser]:
         return request
 
-    def handle_upstream_chunk(self, chunk: bytes) -> bytes:
+    def handle_upstream_chunk(self, chunk: memoryview) -> memoryview:
         return chunk
 
     def on_upstream_connection_close(self) -> None:

--- a/proxy/plugin/man_in_the_middle.py
+++ b/proxy/plugin/man_in_the_middle.py
@@ -27,10 +27,10 @@ class ManInTheMiddlePlugin(HttpProxyBasePlugin):
             self, request: HttpParser) -> Optional[HttpParser]:
         return request
 
-    def handle_upstream_chunk(self, chunk: bytes) -> bytes:
-        return build_http_response(
+    def handle_upstream_chunk(self, chunk: memoryview) -> memoryview:
+        return memoryview(build_http_response(
             httpStatusCodes.OK,
-            reason=b'OK', body=b'Hello from man in the middle')
+            reason=b'OK', body=b'Hello from man in the middle'))
 
     def on_upstream_connection_close(self) -> None:
         pass

--- a/proxy/plugin/mock_rest_api.py
+++ b/proxy/plugin/mock_rest_api.py
@@ -67,18 +67,18 @@ class ProposedRestApiPlugin(HttpProxyBasePlugin):
             return request
         assert request.path
         if request.path in self.REST_API_SPEC:
-            self.client.queue(build_http_response(
+            self.client.queue(memoryview(build_http_response(
                 httpStatusCodes.OK,
                 reason=b'OK',
                 headers={b'Content-Type': b'application/json'},
                 body=bytes_(json.dumps(
                     self.REST_API_SPEC[request.path]))
-            ))
+            )))
         else:
-            self.client.queue(build_http_response(
+            self.client.queue(memoryview(build_http_response(
                 httpStatusCodes.NOT_FOUND,
                 reason=b'NOT FOUND', body=b'Not Found'
-            ))
+            )))
         return None
 
     def handle_upstream_chunk(self, chunk: memoryview) -> memoryview:

--- a/proxy/plugin/mock_rest_api.py
+++ b/proxy/plugin/mock_rest_api.py
@@ -81,7 +81,7 @@ class ProposedRestApiPlugin(HttpProxyBasePlugin):
             ))
         return None
 
-    def handle_upstream_chunk(self, chunk: bytes) -> bytes:
+    def handle_upstream_chunk(self, chunk: memoryview) -> memoryview:
         return chunk
 
     def on_upstream_connection_close(self) -> None:

--- a/proxy/plugin/modify_post_data.py
+++ b/proxy/plugin/modify_post_data.py
@@ -40,7 +40,7 @@ class ModifyPostDataPlugin(HttpProxyBasePlugin):
             request.add_header(b'Content-Type', b'application/json')
         return request
 
-    def handle_upstream_chunk(self, chunk: bytes) -> bytes:
+    def handle_upstream_chunk(self, chunk: memoryview) -> memoryview:
         return chunk
 
     def on_upstream_connection_close(self) -> None:

--- a/proxy/plugin/redirect_to_custom_server.py
+++ b/proxy/plugin/redirect_to_custom_server.py
@@ -38,7 +38,7 @@ class RedirectToCustomServerPlugin(HttpProxyBasePlugin):
             self, request: HttpParser) -> Optional[HttpParser]:
         return request
 
-    def handle_upstream_chunk(self, chunk: bytes) -> bytes:
+    def handle_upstream_chunk(self, chunk: memoryview) -> memoryview:
         return chunk
 
     def on_upstream_connection_close(self) -> None:

--- a/proxy/plugin/shortlink.py
+++ b/proxy/plugin/shortlink.py
@@ -58,22 +58,22 @@ class ShortLinkPlugin(HttpProxyBasePlugin):
         if request.host and request.host != b'localhost' and DOT not in request.host:
             if request.host in self.SHORT_LINKS:
                 path = SLASH if not request.path else request.path
-                self.client.queue(build_http_response(
+                self.client.queue(memoryview(build_http_response(
                     httpStatusCodes.SEE_OTHER, reason=b'See Other',
                     headers={
                         b'Location': b'http://' + self.SHORT_LINKS[request.host] + path,
                         b'Content-Length': b'0',
                         b'Connection': b'close',
                     }
-                ))
+                )))
             else:
-                self.client.queue(build_http_response(
+                self.client.queue(memoryview(build_http_response(
                     httpStatusCodes.NOT_FOUND, reason=b'NOT FOUND',
                     headers={
                         b'Content-Length': b'0',
                         b'Connection': b'close',
                     }
-                ))
+                )))
             return None
         return request
 

--- a/proxy/plugin/shortlink.py
+++ b/proxy/plugin/shortlink.py
@@ -77,7 +77,7 @@ class ShortLinkPlugin(HttpProxyBasePlugin):
             return None
         return request
 
-    def handle_upstream_chunk(self, chunk: bytes) -> bytes:
+    def handle_upstream_chunk(self, chunk: memoryview) -> memoryview:
         return chunk
 
     def on_upstream_connection_close(self) -> None:

--- a/proxy/plugin/web_server_route.py
+++ b/proxy/plugin/web_server_route.py
@@ -32,11 +32,11 @@ class WebServerPlugin(HttpWebServerBasePlugin):
 
     def handle_request(self, request: HttpParser) -> None:
         if request.path == b'/http-route-example':
-            self.client.queue(build_http_response(
-                httpStatusCodes.OK, body=b'HTTP route response'))
+            self.client.queue(memoryview(build_http_response(
+                httpStatusCodes.OK, body=b'HTTP route response')))
         elif request.path == b'/https-route-example':
-            self.client.queue(build_http_response(
-                httpStatusCodes.OK, body=b'HTTPS route response'))
+            self.client.queue(memoryview(build_http_response(
+                httpStatusCodes.OK, body=b'HTTPS route response')))
 
     def on_websocket_open(self) -> None:
         logger.info('Websocket open')

--- a/proxy/testing/test_case.py
+++ b/proxy/testing/test_case.py
@@ -13,6 +13,7 @@ import unittest
 from typing import Optional, List, Generator, Any
 
 from ..proxy import Proxy
+from ..common.constants import DEFAULT_TIMEOUT
 from ..common.utils import get_available_port, new_socket_connection
 from ..plugin import CacheResponsesPlugin
 
@@ -47,8 +48,9 @@ class TestCase(unittest.TestCase):
         cls.wait_for_server(cls.PROXY_PORT)
 
     @staticmethod
-    def wait_for_server(proxy_port: int) -> None:
+    def wait_for_server(proxy_port: int, wait_for_seconds: int = DEFAULT_TIMEOUT) -> None:
         """Wait for proxy.py server to come up."""
+        start_time = time.time()
         while True:
             try:
                 conn = new_socket_connection(
@@ -57,6 +59,9 @@ class TestCase(unittest.TestCase):
                 break
             except ConnectionRefusedError:
                 time.sleep(0.1)
+
+            if time.time() - start_time > wait_for_seconds:
+                break
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/proxy/testing/test_case.py
+++ b/proxy/testing/test_case.py
@@ -61,7 +61,7 @@ class TestCase(unittest.TestCase):
                 time.sleep(0.1)
 
             if time.time() - start_time > wait_for_seconds:
-                break
+                raise TimeoutError('Timed out while waiting for proxy.py to start...')
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/proxy/testing/test_case.py
+++ b/proxy/testing/test_case.py
@@ -40,7 +40,8 @@ class TestCase(unittest.TestCase):
         cls.INPUT_ARGS.append(str(cls.PROXY_PORT))
 
         cls.PROXY = Proxy(input_args=cls.INPUT_ARGS)
-        cls.PROXY.flags.plugins[b'HttpProxyBasePlugin'].append(CacheResponsesPlugin)
+        cls.PROXY.flags.plugins[b'HttpProxyBasePlugin'].append(
+            CacheResponsesPlugin)
 
         cls.PROXY.__enter__()
         cls.wait_for_server(cls.PROXY_PORT)

--- a/tests/common/test_pki.py
+++ b/tests/common/test_pki.py
@@ -22,13 +22,24 @@ class TestPki(unittest.TestCase):
         command = ['my', 'custom', 'command']
         mock_popen.return_value.returncode = 0
         self.assertTrue(pki.run_openssl_command(command, 10))
-        mock_popen.assert_called_with(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        mock_popen.assert_called_with(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
 
     def test_get_ext_config(self) -> None:
         self.assertEqual(pki.get_ext_config(None, None), b'')
         self.assertEqual(pki.get_ext_config([], None), b'')
-        self.assertEqual(pki.get_ext_config(['proxy.py'], None), b'\nsubjectAltName=DNS:proxy.py')
-        self.assertEqual(pki.get_ext_config(None, 'serverAuth'), b'\nextendedKeyUsage=serverAuth')
+        self.assertEqual(
+            pki.get_ext_config(
+                ['proxy.py'],
+                None),
+            b'\nsubjectAltName=DNS:proxy.py')
+        self.assertEqual(
+            pki.get_ext_config(
+                None,
+                'serverAuth'),
+            b'\nextendedKeyUsage=serverAuth')
         self.assertEqual(pki.get_ext_config(['proxy.py'], 'serverAuth'),
                          b'\nsubjectAltName=DNS:proxy.py\nextendedKeyUsage=serverAuth')
         self.assertEqual(pki.get_ext_config(['proxy.py', 'www.proxy.py'], 'serverAuth'),
@@ -44,7 +55,10 @@ class TestPki(unittest.TestCase):
         with pki.ssl_config(['proxy.py']) as (config_path, has_extension):
             self.assertTrue(has_extension)
             with open(config_path, 'rb') as config:
-                self.assertEqual(config.read(), pki.DEFAULT_CONFIG + b'\n[PROXY]\nsubjectAltName=DNS:proxy.py')
+                self.assertEqual(
+                    config.read(),
+                    pki.DEFAULT_CONFIG +
+                    b'\n[PROXY]\nsubjectAltName=DNS:proxy.py')
 
     def test_extfile_no_ext(self) -> None:
         with pki.ext_file() as config_path:
@@ -54,7 +68,9 @@ class TestPki(unittest.TestCase):
     def test_extfile(self) -> None:
         with pki.ext_file(['proxy.py']) as config_path:
             with open(config_path, 'rb') as config:
-                self.assertEqual(config.read(), b'\nsubjectAltName=DNS:proxy.py')
+                self.assertEqual(
+                    config.read(),
+                    b'\nsubjectAltName=DNS:proxy.py')
 
     def test_gen_private_key(self) -> None:
         pass

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -12,7 +12,7 @@ import socket
 import unittest
 from unittest import mock
 
-from proxy.common.constants import DEFAULT_IPV6_HOSTNAME, DEFAULT_IPV4_HOSTNAME, DEFAULT_PORT
+from proxy.common.constants import DEFAULT_IPV6_HOSTNAME, DEFAULT_IPV4_HOSTNAME, DEFAULT_PORT, DEFAULT_TIMEOUT
 from proxy.common.utils import new_socket_connection, socket_connection
 
 
@@ -41,7 +41,7 @@ class TestSocketConnectionUtils(unittest.TestCase):
     @mock.patch('socket.create_connection')
     def test_new_socket_connection_dual(self, mock_socket: mock.Mock) -> None:
         conn = new_socket_connection(self.addr_dual)
-        mock_socket.assert_called_with(self.addr_dual)
+        mock_socket.assert_called_with(self.addr_dual, timeout=DEFAULT_TIMEOUT)
         self.assertEqual(conn, mock_socket.return_value)
 
     @mock.patch('proxy.common.utils.new_socket_connection')

--- a/tests/http/test_protocol_handler.py
+++ b/tests/http/test_protocol_handler.py
@@ -86,7 +86,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
         self.assertTrue(
             cast(HttpProxyPlugin, self.protocol_handler.plugins['HttpProxyPlugin']).server is not None)
         self.assertEqual(
-            self.protocol_handler.client.buffer,
+            self.protocol_handler.client.buffer[0],
             HttpProxyPlugin.PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT)
         mock_server_connection.assert_called_once()
         server.connect.assert_called_once()
@@ -94,7 +94,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
         server.closed = False
 
         parser = HttpParser(httpParserTypes.RESPONSE_PARSER)
-        parser.parse(self.protocol_handler.client.buffer)
+        parser.parse(self.protocol_handler.client.buffer[0].tobytes())
         self.assertEqual(parser.state, httpParserStates.COMPLETE)
         assert parser.code is not None
         self.assertEqual(int(parser.code), 200)
@@ -158,7 +158,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
         ])
         self.protocol_handler.run_once()
         self.assertEqual(
-            self.protocol_handler.client.buffer,
+            self.protocol_handler.client.buffer[0],
             ProxyConnectionFailed.RESPONSE_PKT)
 
     @mock.patch('selectors.DefaultSelector')
@@ -184,7 +184,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
         ])
         self.protocol_handler.run_once()
         self.assertEqual(
-            self.protocol_handler.client.buffer,
+            self.protocol_handler.client.buffer[0],
             ProxyAuthenticationFailed.RESPONSE_PKT)
 
     @mock.patch('selectors.DefaultSelector')

--- a/tests/http/test_web_server.py
+++ b/tests/http/test_web_server.py
@@ -107,7 +107,7 @@ class TestWebServerPlugin(unittest.TestCase):
             self.protocol_handler.request.state,
             httpParserStates.COMPLETE)
         self.assertEqual(
-            self.protocol_handler.client.buffer,
+            self.protocol_handler.client.buffer[0],
             HttpWebServerPlugin.DEFAULT_404_RESPONSE)
 
     @mock.patch('selectors.DefaultSelector')

--- a/tests/plugin/test_http_proxy_plugins.py
+++ b/tests/plugin/test_http_proxy_plugins.py
@@ -112,7 +112,7 @@ class TestHttpProxyPluginExamples(unittest.TestCase):
 
         mock_server_conn.assert_not_called()
         self.assertEqual(
-            self.protocol_handler.client.buffer,
+            self.protocol_handler.client.buffer[0].tobytes(),
             build_http_response(
                 httpStatusCodes.OK, reason=b'OK',
                 headers={b'Content-Type': b'application/json'},
@@ -172,7 +172,7 @@ class TestHttpProxyPluginExamples(unittest.TestCase):
 
         mock_server_conn.assert_not_called()
         self.assertEqual(
-            self.protocol_handler.client.buffer,
+            self.protocol_handler.client.buffer[0].tobytes(),
             build_http_response(
                 status_code=httpStatusCodes.I_AM_A_TEAPOT,
                 reason=b'I\'m a tea pot',
@@ -247,7 +247,7 @@ class TestHttpProxyPluginExamples(unittest.TestCase):
                 reason=b'OK', body=b'Original Response From Upstream')
         self.protocol_handler.run_once()
         self.assertEqual(
-            self.protocol_handler.client.buffer,
+            self.protocol_handler.client.buffer[0].tobytes(),
             build_http_response(
                 httpStatusCodes.OK,
                 reason=b'OK', body=b'Hello from man in the middle')

--- a/tests/plugin/test_http_proxy_plugins_with_tls_interception.py
+++ b/tests/plugin/test_http_proxy_plugins_with_tls_interception.py
@@ -135,7 +135,7 @@ class TestHttpProxyPluginExamplesWithTlsInterception(unittest.TestCase):
         self._conn.send.assert_called_with(
             HttpProxyPlugin.PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT
         )
-        self.assertEqual(self.protocol_handler.client.buffer, b'')
+        self.assertFalse(self.protocol_handler.client.has_buffer())
 
     def test_modify_post_data_plugin(self) -> None:
         original = b'{"key": "value"}'
@@ -186,7 +186,7 @@ class TestHttpProxyPluginExamplesWithTlsInterception(unittest.TestCase):
                 reason=b'OK', body=b'Original Response From Upstream')
         self.protocol_handler.run_once()
         self.assertEqual(
-            self.protocol_handler.client.buffer,
+            self.protocol_handler.client.buffer[0].tobytes(),
             build_http_response(
                 httpStatusCodes.OK,
                 reason=b'OK', body=b'Hello from man in the middle')

--- a/tests/testing/test_embed.py
+++ b/tests/testing/test_embed.py
@@ -70,7 +70,7 @@ class TestProxyPyEmbedded(TestCase):
             'http': 'http://localhost:%d' % self.PROXY_PORT,
         })
         opener = urllib.request.build_opener(proxy_handler)
-        with self.assertRaises(urllib.error.HTTPError) as e:
+        with self.assertRaises(urllib.error.HTTPError):
             r: http.client.HTTPResponse = opener.open(
                 'http://localhost:%d/' %
                 self.PROXY_PORT, timeout=10)

--- a/tests/testing/test_embed.py
+++ b/tests/testing/test_embed.py
@@ -8,9 +8,9 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 """
-import json
 import http.client
 import urllib.request
+import urllib.error
 
 from proxy import TestCase
 from proxy.common.constants import DEFAULT_CLIENT_RECVBUF_SIZE, PROXY_AGENT_HEADER_VALUE
@@ -70,8 +70,10 @@ class TestProxyPyEmbedded(TestCase):
             'http': 'http://localhost:%d' % self.PROXY_PORT,
         })
         opener = urllib.request.build_opener(proxy_handler)
-        r: http.client.HTTPResponse = opener.open('http://httpbin.org/get')
-        self.assertEqual(r.status, 200)
-        data = json.loads(r.read(DEFAULT_CLIENT_RECVBUF_SIZE))
-        self.assertEqual(data['args'], {})
-        self.assertEqual(data['headers']['Host'], 'httpbin.org')
+        with self.assertRaises(urllib.error.HTTPError) as e:
+            r: http.client.HTTPResponse = opener.open(
+                'http://localhost:%d/' %
+                self.PROXY_PORT, timeout=10)
+            self.assertEqual(r.status, 404)
+            self.assertEqual(r.headers.get('server'), PROXY_AGENT_HEADER_VALUE)
+            self.assertEqual(r.headers.get('connection'), b'close')

--- a/tests/testing/test_embed.py
+++ b/tests/testing/test_embed.py
@@ -8,6 +8,8 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 """
+import os
+import unittest
 import http.client
 import urllib.request
 import urllib.error
@@ -19,6 +21,8 @@ from proxy.http.codes import httpStatusCodes
 from proxy.http.methods import httpMethods
 
 
+@unittest.skipIf(os.environ.get('GITHUB_ACTIONS', False),
+                 'Disabled on GitHub actions because proxy.py setup hangs')
 class TestProxyPyEmbedded(TestCase):
     """This test case is a demonstration of proxy.TestCase and also serves as
     integration test suite for proxy.py."""

--- a/tests/testing/test_embed.py
+++ b/tests/testing/test_embed.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 """
+import unittest
 import http.client
 import urllib.request
 import urllib.error
@@ -19,6 +20,7 @@ from proxy.http.codes import httpStatusCodes
 from proxy.http.methods import httpMethods
 
 
+@unittest.skipIf(True, 'Disabled as it hang on GitHub actions')
 class TestProxyPyEmbedded(TestCase):
     """This test case is a demonstration of proxy.TestCase and also serves as
     integration test suite for proxy.py."""

--- a/tests/testing/test_embed.py
+++ b/tests/testing/test_embed.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 """
+import os
 import unittest
 import http.client
 import urllib.request
@@ -20,7 +21,8 @@ from proxy.http.codes import httpStatusCodes
 from proxy.http.methods import httpMethods
 
 
-@unittest.skipIf(True, 'Disabled as it hang on GitHub actions')
+@unittest.skipIf(os.environ.get('GITHUB_ACTIONS', False),
+                 'Disabled on GitHub actions because proxy.py setup hangs')
 class TestProxyPyEmbedded(TestCase):
     """This test case is a demonstration of proxy.TestCase and also serves as
     integration test suite for proxy.py."""

--- a/tests/testing/test_embed.py
+++ b/tests/testing/test_embed.py
@@ -8,8 +8,6 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 """
-import os
-import unittest
 import http.client
 import urllib.request
 import urllib.error
@@ -21,8 +19,6 @@ from proxy.http.codes import httpStatusCodes
 from proxy.http.methods import httpMethods
 
 
-@unittest.skipIf(os.environ.get('GITHUB_ACTIONS', False),
-                 'Disabled on GitHub actions because proxy.py setup hangs')
 class TestProxyPyEmbedded(TestCase):
     """This test case is a demonstration of proxy.TestCase and also serves as
     integration test suite for proxy.py."""

--- a/tests/testing/test_test_case.py
+++ b/tests/testing/test_test_case.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+    proxy.py
+    ~~~~~~~~
+    ⚡⚡⚡ Fast, Lightweight, Pluggable, TLS interception capable proxy server focused on
+    Network monitoring, controls & Application development, testing, debugging.
+
+    :copyright: (c) 2013-present by Abhinav Singh and contributors.
+    :license: BSD, see LICENSE for more details.
+"""
+import unittest
+import proxy
+
+from proxy.common.utils import get_available_port
+
+
+class TestTestCase(unittest.TestCase):
+
+    def test_wait_for_server(self) -> None:
+        with self.assertRaises(TimeoutError):
+            proxy.TestCase.wait_for_server(get_available_port(), wait_for_seconds=1)


### PR DESCRIPTION
Ideally, eventually, we shouldn't be making copies of data received over the network.  Currently, `.tobytes` is used in several places, specially because parser is currently not `memoryview` compliant.  Real blocker includes abstracting list of memoryview's as a single contiguous memory block.  Address some of #187 