### PR TITLE
SAN extension required for TLS interception certificate generation

### DIFF
--- a/tests/common/test_pki.py
+++ b/tests/common/test_pki.py
@@ -33,20 +33,20 @@ class TestPki(unittest.TestCase):
     def test_get_ext_config(self) -> None:
         self.assertEqual(pki.get_ext_config(None, None), b'')
         self.assertEqual(pki.get_ext_config([], None), b'')
-        self.assertEqual(
-            pki.get_ext_config(
-                ['proxy.py'],
-                None),
-            b'\nsubjectAltName=DNS:proxy.py')
-        self.assertEqual(
-            pki.get_ext_config(
-                None,
-                'serverAuth'),
-            b'\nextendedKeyUsage=serverAuth')
+        self.assertEqual(pki.get_ext_config(
+            ['proxy.py'], None), b'[SAN]\nsubjectAltName=DNS:proxy.py')
+        self.assertEqual(pki.get_ext_config(None, 'serverAuth'),
+                         b'[PROXY]\nextendedKeyUsage=serverAuth')
         self.assertEqual(pki.get_ext_config(['proxy.py'], 'serverAuth'),
-                         b'\nsubjectAltName=DNS:proxy.py\nextendedKeyUsage=serverAuth')
+                         b'[SAN]\nsubjectAltName=DNS:proxy.py[PROXY]\nextendedKeyUsage=serverAuth')
         self.assertEqual(pki.get_ext_config(['proxy.py', 'www.proxy.py'], 'serverAuth'),
-                         b'\nsubjectAltName=DNS:proxy.py,DNS:www.proxy.py\nextendedKeyUsage=serverAuth')
+                         b'[SAN]\nsubjectAltName=DNS:proxy.py,DNS:www.proxy.py[PROXY]\nextendedKeyUsage=serverAuth')
+        self.assertEqual(pki.get_ext_config(
+            ['proxy.py']), b'[SAN]\nsubjectAltName=DNS:proxy.py')
+        self.assertEqual(pki.get_ext_config(
+            ['proxy.py']), b'[SAN]\nsubjectAltName=DNS:proxy.py')
+        self.assertEqual(pki.get_ext_config(['proxy.py', 'www.proxy.py']),
+                         b'[SAN]\nsubjectAltName=DNS:proxy.py,DNS:www.proxy.py')
 
     def test_ssl_config_no_ext(self) -> None:
         with pki.ssl_config() as (config_path, has_extension):
@@ -61,7 +61,7 @@ class TestPki(unittest.TestCase):
                 self.assertEqual(
                     config.read(),
                     pki.DEFAULT_CONFIG +
-                    b'\n[PROXY]\nsubjectAltName=DNS:proxy.py')
+                    b'[SAN]\nsubjectAltName=DNS:proxy.py')
 
     def test_extfile_no_ext(self) -> None:
         with pki.ext_file() as config_path:
@@ -73,7 +73,7 @@ class TestPki(unittest.TestCase):
             with open(config_path, 'rb') as config:
                 self.assertEqual(
                     config.read(),
-                    b'\nsubjectAltName=DNS:proxy.py')
+                    b'[SAN]\nsubjectAltName=DNS:proxy.py')
 
     def test_gen_private_key(self) -> None:
         key_path, nopass_key_path = self._gen_private_key()
@@ -93,26 +93,55 @@ class TestPki(unittest.TestCase):
     def test_gen_csr(self) -> None:
         key_path, nopass_key_path, crt_path = self._gen_public_private_key()
         csr_path = os.path.join(tempfile.gettempdir(), 'test_gen_public.csr')
-        pki.gen_csr(csr_path, key_path, 'password', crt_path)
+        pki.gen_csr(csr_path, nopass_key_path,
+                    '/C=/ST=/L=/O=/OU=/CN=example.com')
         self.assertTrue(os.path.exists(csr_path))
         # TODO: Assert CSR is valid for provided crt and key
         os.remove(csr_path)
-        os.remove(crt_path)
         os.remove(key_path)
         os.remove(nopass_key_path)
 
     def test_sign_csr(self) -> None:
-        pass
+        key_path, nopass_key_path, crt_path = self._gen_public_private_key()
+        key_path, nopass_key_path_signed = self._gen_private_key()
+
+        csr_path = os.path.join(tempfile.gettempdir(), 'test_gen_public.csr')
+        pki.gen_csr(csr_path, nopass_key_path_signed,
+                    '/C=/ST=/L=/O=/OU=/CN=example.com')
+
+        csr_path_signed = os.path.join(tempfile.gettempdir(),
+                                       'test_gen_public_signed.pem')
+        pki.sign_csr(csr_path, csr_path_signed, nopass_key_path, crt_path,
+                     str(123), ["example.com"])
+        self.assertTrue(os.path.exists(csr_path_signed))
+        os.remove(csr_path)
+        os.remove(crt_path)
+        os.remove(key_path)
+        os.remove(nopass_key_path)
+        os.remove(csr_path_signed)
+
+    def test_gen_web_cert(self) -> None:
+        key_path, nopass_key_path, crt_path = self._gen_public_private_key()
+        key_path, nopass_key_path_signed = self._gen_private_key()
+
+        out = os.path.join(tempfile.gettempdir(),
+                           'web-csr.pem')
+        pki.gen_crt(out, nopass_key_path_signed, nopass_key_path,
+                    crt_path, "example.com", str(123))
+
+        self.assertTrue(os.path.exists(out))
 
     def _gen_public_private_key(self) -> Tuple[str, str, str]:
         key_path, nopass_key_path = self._gen_private_key()
         crt_path = os.path.join(tempfile.gettempdir(), 'test_gen_public.crt')
-        pki.gen_public_key(crt_path, key_path, 'password', '/CN=example.com')
+        pki.gen_public_key(crt_path, nopass_key_path,
+                           "password", '/CN=example.com')
         return (key_path, nopass_key_path, crt_path)
 
     def _gen_private_key(self) -> Tuple[str, str]:
         key_path = os.path.join(tempfile.gettempdir(), 'test_gen_private.key')
-        nopass_key_path = os.path.join(tempfile.gettempdir(), 'test_gen_private_nopass.key')
+        nopass_key_path = os.path.join(
+            tempfile.gettempdir(), 'test_gen_private_nopass.key')
         pki.gen_private_key(key_path, 'password')
         pki.remove_passphrase(key_path, 'password', nopass_key_path)
         return (key_path, nopass_key_path)


### PR DESCRIPTION
Hi,

When using locally proxy.py, I saw that, with FF, everything looks good, but with Brave/Chrome that was not the case.
Thx of the console of chrome, it says that there is currently two issues on our certificates : 
- that was in sha1, not enought for chrome -> it needs sha256,
- the certificate must have SAN information (subectAltName)

This PR, should solved this issue. 
Regarding the code, the main problem was to generate on the fly certs with the SAN information.
I tried billions of time & differents solutions, but I was not able to make it on the fly.
Currently, I am generating and consuming a file, before to remove it. I think, it will make a lot of I/O access, and should be powerless... 
So, I am waiting your comment to find the best solution. 




Ressources : 
https://www.fomfus.com/articles/how-to-generate-self-signed-certificates-with-san-subject-alternative-name

Edit : 
The 'solution' was to put something like that in the signing process to add the SAN on the fly, but that's not working with python (but working well in direct shell) 
```
'-extfile','<(printf "[SAN]\nsubjectAltName=DNS:CurrentTld")'
```
But that doesnt work at all

Edit 2 : the base branch is the one for the #258, hope that's not a problem for you. 


