### PR TITLE
Add urlparse fix for Python 3.6.x .  Deprecate support for Python 3.5.x

### DIFF
--- a/proxy/common/version.py
+++ b/proxy/common/version.py
@@ -8,5 +8,5 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 """
-VERSION = (2, 1, 1)
+VERSION = (2, 1, 2)
 __version__ = '.'.join(map(str, VERSION[0:3]))

--- a/proxy/http/parser.py
+++ b/proxy/http/parser.py
@@ -111,9 +111,13 @@ class HttpParser:
     def set_line_attributes(self) -> None:
         if self.type == httpParserTypes.REQUEST_PARSER:
             if self.method == httpMethods.CONNECT and self.url:
-                self.host = self.url.scheme
-                self.port = 443 if self.url.path == b'' else \
-                    int(self.url.path)
+                if self.url.scheme == b'':
+                    u = urlparse.urlsplit(b'//' + self.url.path)
+                    self.host, self.port = u.hostname, u.port
+                else:
+                    self.host = self.url.scheme
+                    self.port = 443 if self.url.path == b'' else \
+                        int(self.url.path)
             elif self.url:
                 self.host, self.port = self.url.hostname, self.url.port \
                     if self.url.port else DEFAULT_HTTP_PORT

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
         long_description_content_type='text/markdown',
         download_url=__download_url__,
         license=__license__,
-        python_requires='!=2.*, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+        python_requires='!=2.*, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
         zip_safe=False,
         packages=find_packages(exclude=['tests', 'tests.*']),
         package_data={'proxy': ['py.typed']},

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 """
 from setuptools import setup, find_packages
 
-VERSION = (2, 1, 1)
+VERSION = (2, 1, 2)
 __version__ = '.'.join(map(str, VERSION[0:3]))
 __description__ = '''⚡⚡⚡Fast, Lightweight, Pluggable, TLS interception capable proxy server
     focused on Network monitoring, controls & Application development, testing, debugging.'''


### PR DESCRIPTION
- Python 3.5.x no longer recognizes typing syntax
- urlparse is still returning old style result on 3.6.x