### PR TITLE
[CacheResponsesPlugin] Serving out of cache

### DIFF
--- a/proxy/plugin/cache/base.py
+++ b/proxy/plugin/cache/base.py
@@ -11,9 +11,13 @@
 import logging
 from typing import Optional, Any
 
-from ...http.parser import HttpParser
-from ...http.proxy import HttpProxyBasePlugin
 from .store.base import CacheStore
+from ...http.parser import HttpParser, httpParserTypes
+from ...http.proxy import HttpProxyBasePlugin
+from ...http.codes import httpStatusCodes
+from ...common.constants import PROXY_AGENT_HEADER_VALUE
+from ...common.utils import text_
+from ...common.utils import build_http_response
 
 logger = logging.getLogger(__name__)
 
@@ -40,16 +44,60 @@ class BaseCacheResponsesPlugin(HttpProxyBasePlugin):
     def before_upstream_connection(
             self, request: HttpParser) -> Optional[HttpParser]:
         assert self.store
+        logger.info("Upstream connexion %s:%d %s" %
+                    (text_(request.host), request.port if request.port else 0, text_(request.path)))
+
+        if request.port == 443:
+            return request
+
         try:
-            self.store.open(request)
+            if self.store.is_cached(request):
+                return None
         except Exception as e:
-            logger.info('Caching disabled due to exception message %s', str(e))
+            logger.info('Caching disabled due to exception message: %s', str(e))
+
         return request
 
     def handle_client_request(
             self, request: HttpParser) -> Optional[HttpParser]:
         assert self.store
-        return self.store.cache_request(request)
+        logger.info("Client request %s:%d %s" %
+                    (text_(request.host), request.port if request.port else 0, text_(request.path)))
+
+        if request.port == 443:
+            return request
+
+        try:
+            msg = self.store.cache_request(request)
+            if (msg.type == httpParserTypes.REQUEST_PARSER):
+                return msg
+            elif (msg.type == httpParserTypes.RESPONSE_PARSER):
+                self.client.queue(memoryview(build_http_response(
+                    int(msg.code) if msg.code is not None else 0,
+                    reason=msg.reason,
+                    headers={k: v for k, v in msg.headers.values()},
+                    body=msg.body
+                )))
+                return None
+            else:
+                raise ValueError('Bad HTTPParser type: %s' % msg.type)
+        except Exception as e:
+            logger.info('Caching disabled due to exception message: %s', str(e))
+
+        try:
+            if self.store.is_cached(request):
+                self.client.queue(memoryview(build_http_response(
+                    httpStatusCodes.INTERNAL_SERVER_ERROR,
+                    reason=b'Internal server error',
+                    headers={
+                        b'Server': PROXY_AGENT_HEADER_VALUE,
+                        b'Connection': b'close',
+                    }
+                )))
+        except Exception as e:
+            logger.info('Caching disabled due to exception message: %s', str(e))
+
+        return request
 
     def handle_upstream_chunk(self, chunk: memoryview) -> memoryview:
         assert self.store

--- a/proxy/plugin/cache/base.py
+++ b/proxy/plugin/cache/base.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import logging
+import multiprocessing
 from typing import Optional, Any
 
 from .store.base import CacheStore
@@ -31,18 +32,37 @@ class BaseCacheResponsesPlugin(HttpProxyBasePlugin):
     Different storage backends can be used per request if required.
     """
 
+    class EnabledDescriptor:
+        def __init__(self, enabled: bool = False) -> None:
+            self.enabled = multiprocessing.Event()
+            if enabled:
+                self.enabled.set()
+
+        def __get__(self, obj: Optional[object], owner: type) -> Any:
+            if obj is None:
+                return self.enabled
+            return None
+
+    # Dynamically enable / disable cache
+    enabled = EnabledDescriptor(True)
+
     def __init__(
             self,
             *args: Any,
             **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.store: Optional[CacheStore] = None
+        self.__enabled: Optional[bool] = None
 
     def set_store(self, store: CacheStore) -> None:
         self.store = store
 
     def before_upstream_connection(
             self, request: HttpParser) -> Optional[HttpParser]:
+        self.__enabled = self.__class__.enabled.is_set()
+        if not self.__enabled:
+            return request
+
         assert self.store
         logger.info("Upstream connexion %s:%d %s" %
                     (text_(request.host), request.port if request.port else 0, text_(request.path)))
@@ -60,6 +80,10 @@ class BaseCacheResponsesPlugin(HttpProxyBasePlugin):
 
     def handle_client_request(
             self, request: HttpParser) -> Optional[HttpParser]:
+        assert self.__enabled is not None
+        if not self.__enabled:
+            return request
+
         assert self.store
         logger.info("Client request %s:%d %s" %
                     (text_(request.host), request.port if request.port else 0, text_(request.path)))
@@ -100,9 +124,17 @@ class BaseCacheResponsesPlugin(HttpProxyBasePlugin):
         return request
 
     def handle_upstream_chunk(self, chunk: memoryview) -> memoryview:
+        assert self.__enabled is not None
+        if not self.__enabled:
+            return chunk
+
         assert self.store
         return self.store.cache_response_chunk(chunk)
 
     def on_upstream_connection_close(self) -> None:
+        assert self.__enabled is not None
+        if not self.__enabled:
+            return
+
         assert self.store
         self.store.close()

--- a/proxy/plugin/cache/cache_responses.py
+++ b/proxy/plugin/cache/cache_responses.py
@@ -8,7 +8,6 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 """
-import multiprocessing
 import tempfile
 from typing import Any
 
@@ -18,9 +17,6 @@ from .base import BaseCacheResponsesPlugin
 
 class CacheResponsesPlugin(BaseCacheResponsesPlugin):
     """Caches response using OnDiskCacheStore."""
-
-    # Dynamically enable / disable cache
-    ENABLED = multiprocessing.Event()
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/proxy/plugin/cache/store/base.py
+++ b/proxy/plugin/cache/store/base.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for more details.
 """
 from abc import ABC, abstractmethod
-from typing import Optional
 from uuid import UUID
 from ....http.parser import HttpParser
 
@@ -24,7 +23,11 @@ class CacheStore(ABC):
         pass
 
     @abstractmethod
-    def cache_request(self, request: HttpParser) -> Optional[HttpParser]:
+    def is_cached(self, request: HttpParser) -> bool:
+        pass
+
+    @abstractmethod
+    def cache_request(self, request: HttpParser) -> HttpParser:
         return request
 
     @abstractmethod

--- a/proxy/plugin/cache/store/disk.py
+++ b/proxy/plugin/cache/store/disk.py
@@ -30,12 +30,14 @@ class OnDiskCacheStore(CacheStore):
         self.cache_file: Optional[BinaryIO] = None
 
     def open(self, request: HttpParser) -> None:
-        self.cache_file_path = os.path.join(
-            self.cache_dir,
-            '%s-%s.txt' % (text_(request.host), self.uid.hex))
-        self.cache_file = open(self.cache_file_path, "wb")
+        pass
 
     def cache_request(self, request: HttpParser) -> Optional[HttpParser]:
+        self.cache_file_path = os.path.join(self.cache_dir, '%s-%s.txt' % (text_(request.host), self.uid.hex))
+
+        if self.cache_file:
+            self.cache_file.close()
+        self.cache_file = open(self.cache_file_path, "ab")
         return request
 
     def cache_response_chunk(self, chunk: memoryview) -> memoryview:

--- a/proxy/plugin/cache/store/disk.py
+++ b/proxy/plugin/cache/store/disk.py
@@ -45,7 +45,7 @@ class OnDiskCacheStore(CacheStore):
 
     def get_cache_file_path(self, request: HttpParser, create: bool = False) -> str:
         request_method = text_(request.method)
-        request_host = text_(request.host)
+        request_host = text_(request.host if request.host else request.headers[b'host'][1])
         request_path = text_(request.path)
         request_body = sha512(request.body).hexdigest() if request.body else 'None'
 

--- a/proxy/plugin/cache/store/disk.py
+++ b/proxy/plugin/cache/store/disk.py
@@ -26,6 +26,8 @@ class OnDiskCacheStore(CacheStore):
     def __init__(self, uid: UUID, cache_dir: str) -> None:
         super().__init__(uid)
         self.cache_dir = cache_dir
+        if not os.path.isdir(self.cache_dir):
+            os.mkdir(self.cache_dir)
         self.cache_file_path: Optional[str] = None
         self.cache_file: Optional[BinaryIO] = None
 

--- a/proxy/plugin/cache/store/disk.py
+++ b/proxy/plugin/cache/store/disk.py
@@ -86,6 +86,7 @@ class OnDiskCacheStore(CacheStore):
         if self.cache_file:
             logger.debug("Closing cache file")
             self.cache_file.close()
+            self.cache_list.flush()
         logger.info('Caching in file: %s' % cache_file_path)
         self.cache_file = open(cache_file_path, "ab")
         return request
@@ -99,3 +100,4 @@ class OnDiskCacheStore(CacheStore):
         if self.cache_file:
             logger.debug("Closing cache file")
             self.cache_file.close()
+            self.cache_list.flush()

--- a/proxy/testing/test_case.py
+++ b/proxy/testing/test_case.py
@@ -44,8 +44,8 @@ class TestCase(unittest.TestCase):
         cls.INPUT_ARGS.append(str(cls.PROXY_PORT))
 
         cls.PROXY = Proxy(input_args=cls.INPUT_ARGS)
-        cls.PROXY.flags.plugins[b'HttpProxyBasePlugin'].append(
-            CacheResponsesPlugin)
+        cls.PROXY.flags.plugins[b'HttpProxyBasePlugin'].append(CacheResponsesPlugin)
+        CacheResponsesPlugin.enabled.clear()
 
         cls.PROXY.__enter__()
         cls.wait_for_server(cls.PROXY_PORT)
@@ -79,10 +79,10 @@ class TestCase(unittest.TestCase):
     @contextlib.contextmanager
     def vcr(self) -> Generator[None, None, None]:
         try:
-            CacheResponsesPlugin.ENABLED.set()
+            CacheResponsesPlugin.enabled.set()
             yield
         finally:
-            CacheResponsesPlugin.ENABLED.clear()
+            CacheResponsesPlugin.enabled.clear()
 
     def run(self, result: Optional[unittest.TestResult] = None) -> Any:
         super().run(result)

--- a/tests/plugin/test_http_proxy_plugins.py
+++ b/tests/plugin/test_http_proxy_plugins.py
@@ -409,7 +409,7 @@ class TestHttpProxyPluginExamples(unittest.TestCase):
         # Setup cache:
         cache_file_name = 'test'
         with open(Path(tempfile.gettempdir()) / 'list.txt', 'wt') as cache_list:
-            cache_list.write('GET example.org /get None %s' % cache_file_name)
+            cache_list.write('GET example.org /get None %s\n' % cache_file_name)
         with open(Path(tempfile.gettempdir()) / ('proxy-cache-' + cache_file_name), 'wb') as cache_file:
             cache_file.write(cache_response)
 

--- a/tests/plugin/test_http_proxy_plugins.py
+++ b/tests/plugin/test_http_proxy_plugins.py
@@ -294,7 +294,7 @@ class TestHttpProxyPluginExamples(unittest.TestCase):
         )
 
     @mock.patch('proxy.http.proxy.server.TcpServerConnection')
-    def test_cache_responses_plugin(self, mock_server_conn: mock.Mock) -> None:
+    def test_cache_responses_plugin_cache(self, mock_server_conn: mock.Mock) -> None:
         request = build_http_request(
             b'GET', b'http://example.org/get',
             headers={

--- a/tests/plugin/utils.py
+++ b/tests/plugin/utils.py
@@ -25,7 +25,7 @@ def get_plugin_by_test_name(test_name: str) -> Type[HttpProxyBasePlugin]:
         plugin = RedirectToCustomServerPlugin
     elif test_name == 'test_filter_by_upstream_host_plugin':
         plugin = FilterByUpstreamHostPlugin
-    elif test_name == 'test_cache_responses_plugin':
+    elif test_name.startswith('test_cache_responses_plugin'):
         plugin = CacheResponsesPlugin
     elif test_name == 'test_man_in_the_middle_plugin':
         plugin = ManInTheMiddlePlugin

--- a/tests/testing/test_embed.py
+++ b/tests/testing/test_embed.py
@@ -48,7 +48,7 @@ class TestProxyPyEmbedded(TestCase):
                     method, host, path, body, cache_file_name = cache_line.strip().split(' ')
                     if ((method == expected_method) and (host == expected_host) and
                             (path == expected_path) and (body == expected_body)):
-                        return cache_file_name
+                        return 'proxy-cache-' + cache_file_name
             time.sleep(1)
             if (timeout > 0):
                 timeout -= 1
@@ -57,7 +57,7 @@ class TestProxyPyEmbedded(TestCase):
 
     def tearDown(self) -> None:
         tmpDir = Path(tempfile.gettempdir())
-        for f in tmpDir.glob('localhost-*.txt'):
+        for f in tmpDir.glob('proxy-cache-*'):
             if f.is_file():
                 os.remove(f)
         os.remove(tmpDir / 'list.txt')
@@ -86,6 +86,7 @@ class TestProxyPyEmbedded(TestCase):
 
         cache_file_name = self.waitCached(Path(tempfile.gettempdir()) / 'list.txt',
                                           'GET', 'localhost', '/', 'None')
+        self.assertTrue(os.path.isfile(Path(tempfile.gettempdir()) / cache_file_name))
 
         with open(Path(tempfile.gettempdir()) / cache_file_name, 'rb') as cache_file:
             self.assertEqual(cache_file.read(), build_http_response(
@@ -127,6 +128,7 @@ class TestProxyPyEmbedded(TestCase):
 
         cache_file_name = self.waitCached(Path(tempfile.gettempdir()) / 'list.txt',
                                           'GET', 'localhost', '/', 'None')
+        self.assertTrue(os.path.isfile(Path(tempfile.gettempdir()) / cache_file_name))
 
         with open(Path(tempfile.gettempdir()) / cache_file_name, 'rb') as cache_file:
             self.assertEqual(cache_file.read(), build_http_response(


### PR DESCRIPTION
Here is a basic implementation of a cache plugin which supports serving responses out of cache. This should be the base of the solution to #319. Tests are attached for caching and serving HTTP and HTTPS requests.

The implementation is done as follows. A list file (`list.txt`) has been added which list all completed requests (method, host, path and SHA512 hash of body). When a request arrives, the plugin searches the list for this request. If it is not stored, create the entry and fetch response from server, otherwise queue the cached response to the client (and do not connect to the server).

It does not support interception of SSL handshake, which means it needs to connect to the server even though the request is cached. I think this requires a modification of the `proxy.http.proxy.server` class, so that it can perform an SSL handshake with the client without performing one with an upstream server.
