### PR TITLE
Relax proxy auth requirement to allow mixed case for the auth type

### DIFF
--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -535,8 +535,10 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
 
     def authenticate(self) -> None:
         if self.flags.auth_code:
-            if b'proxy-authorization' not in self.request.headers or \
-                    self.request.headers[b'proxy-authorization'][1] != self.flags.auth_code:
+            if b'proxy-authorization' not in self.request.headers:
+                raise ProxyAuthenticationFailed()
+            parts = self.request.headers[b'proxy-authorization'][1].split()
+            if len(parts) != 2 and parts[0].lower() != b'basic' and parts[1] != self.flags.auth_code:
                 raise ProxyAuthenticationFailed()
 
     def connect_upstream(self) -> None:

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -203,7 +203,7 @@ class Proxy:
         # Generate auth_code required for basic authentication if enabled
         auth_code = None
         if args.basic_auth:
-            auth_code = b'Basic %s' % base64.b64encode(bytes_(args.basic_auth))
+            auth_code = base64.b64encode(bytes_(args.basic_auth))
 
         return Flags(
             plugins=plugins,

--- a/tests/http/test_protocol_handler.py
+++ b/tests/http/test_protocol_handler.py
@@ -174,8 +174,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
         self._conn = mock_fromfd.return_value
         self.mock_selector_for_client_read(mock_selector)
         flags = Flags(
-            auth_code=b'Basic %s' %
-                      base64.b64encode(b'user:pass'))
+            auth_code=base64.b64encode(b'user:pass'))
         flags.plugins = Proxy.load_plugins([
             b'proxy.http.proxy.HttpProxyPlugin',
             b'proxy.http.server.HttpWebServerPlugin',
@@ -208,8 +207,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
         server.buffer_size.return_value = 0
 
         flags = Flags(
-            auth_code=b'Basic %s' %
-                      base64.b64encode(b'user:pass'))
+            auth_code=base64.b64encode(b'user:pass'))
         flags.plugins = Proxy.load_plugins([
             b'proxy.http.proxy.HttpProxyPlugin',
             b'proxy.http.server.HttpWebServerPlugin',
@@ -258,8 +256,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
             mock_selector, server)
 
         flags = Flags(
-            auth_code=b'Basic %s' %
-                      base64.b64encode(b'user:pass'))
+            auth_code=base64.b64encode(b'user:pass'))
         flags.plugins = Proxy.load_plugins([
             b'proxy.http.proxy.HttpProxyPlugin',
             b'proxy.http.server.HttpWebServerPlugin'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -138,7 +138,7 @@ class TestMain(unittest.TestCase):
         mock_acceptor_pool.assert_called_once()
         self.assertEqual(
             flgs.auth_code,
-            b'Basic dXNlcjpwYXNz')
+            b'dXNlcjpwYXNz')
 
     @mock.patch('time.sleep')
     @mock.patch('builtins.print')


### PR DESCRIPTION
Now "basic", "Basic", "BaSiC" are all allowed as auth type.  This allows for typos without compromising the authentication workflow.  See https://github.com/Anorov/PySocks/pull/147 for some background and https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Proxy-Authorization as reference to specification.

/cc @amirasaran