### PR TITLE
Fixed argument logs passing from python interface

### DIFF
--- a/proxy/core/acceptor/threadless.py
+++ b/proxy/core/acceptor/threadless.py
@@ -122,9 +122,7 @@ class Threadless(multiprocessing.Process):
         try:
             self.works[fileno].initialize()
         except Exception as e:
-            logger.exception(
-                'Exception occurred during initialization',
-                exc_info=e)
+            logger.error(f'Exception occurred during initialization {e}')
             self.cleanup(fileno)
 
     def cleanup_inactive(self) -> None:

--- a/proxy/core/base/tcp_server.py
+++ b/proxy/core/base/tcp_server.py
@@ -36,7 +36,7 @@ class BaseTcpServerHandler(Work):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.must_flush_before_shutdown = False
-        print('Connection accepted from {0}'.format(self.client.addr))
+        #print('Connection accepted from {0}'.format(self.client.addr))
 
     @abstractmethod
     def handle_data(self, data: memoryview) -> Optional[bool]:
@@ -69,38 +69,38 @@ class BaseTcpServerHandler(Work):
                 data = self.client.recv()
                 if data is None:
                     # Client closed connection, signal shutdown
-                    print(
-                        'Connection closed by client {0}'.format(
-                            self.client.addr))
+                    #print(
+                    #    'Connection closed by client {0}'.format(
+                    #        self.client.addr))
                     do_shutdown = True
                 else:
                     r = self.handle_data(data)
                     if isinstance(r, bool) and r is True:
-                        print(
-                            'Implementation signaled shutdown for client {0}'.format(
-                                self.client.addr))
+                        #print(
+                        #    'Implementation signaled shutdown for client {0}'.format(
+                        #        self.client.addr))
                         if self.client.has_buffer():
-                            print(
-                                'Client {0} has pending buffer, will be flushed before shutting down'.format(
-                                    self.client.addr))
+                            #print(
+                            #    'Client {0} has pending buffer, will be flushed before shutting down'.format(
+                            #        self.client.addr))
                             self.must_flush_before_shutdown = True
                         else:
                             do_shutdown = True
             except ConnectionResetError:
-                print(
-                    'Connection reset by client {0}'.format(
-                        self.client.addr))
+                #print(
+                #    'Connection reset by client {0}'.format(
+                #        self.client.addr))
                 do_shutdown = True
 
         if self.client.connection in writables:
-            print('Flushing buffer to client {0}'.format(self.client.addr))
+            #print('Flushing buffer to client {0}'.format(self.client.addr))
             self.client.flush()
             if self.must_flush_before_shutdown is True:
                 do_shutdown = True
             self.must_flush_before_shutdown = False
 
         if do_shutdown:
-            print(
-                'Shutting down client {0} connection'.format(
-                    self.client.addr))
+            #print(
+            #    'Shutting down client {0} connection'.format(
+            #        self.client.addr))
         return do_shutdown

--- a/proxy/core/event/dispatcher.py
+++ b/proxy/core/event/dispatcher.py
@@ -90,4 +90,4 @@ class EventDispatcher:
         except KeyboardInterrupt:
             pass
         except Exception as e:
-            logger.exception('Event dispatcher exception', exc_info=e)
+            logger.error(f'Event dispatcher exception {e}')

--- a/proxy/core/ssh/tunnel.py
+++ b/proxy/core/ssh/tunnel.py
@@ -43,12 +43,12 @@ class Tunnel:
                 username=self.ssh_username,
                 key_filename=self.private_pem_key
             )
-            print('SSH connection established...')
+            #print('SSH connection established...')
             transport: Optional[paramiko.transport.Transport] = ssh.get_transport(
             )
             assert transport is not None
             transport.request_port_forward('', self.remote_proxy_port)
-            print('Tunnel port forward setup successful...')
+            #print('Tunnel port forward setup successful...')
             while True:
                 conn: Optional[paramiko.channel.Channel] = transport.accept(
                     timeout=1)

--- a/proxy/http/handler.py
+++ b/proxy/http/handler.py
@@ -260,9 +260,7 @@ class HttpProtocolHandler(Work):
                 if e.errno == errno.ECONNRESET:
                     logger.warning('%r' % e)
                 else:
-                    logger.exception(
-                        'Exception while receiving from %s connection %r with reason %r' %
-                        (self.client.tag, self.client.connection, e))
+                    logger.error('Exception while receiving from %s connection %r with reason %r' % (self.client.tag, self.client.connection, e))
                 return True
 
             if client_data is None:
@@ -356,10 +354,8 @@ class HttpProtocolHandler(Work):
         except KeyboardInterrupt:  # pragma: no cover
             pass
         except ssl.SSLError as e:
-            logger.exception('ssl.SSLError', exc_info=e)
+            logger.error(f'ssl.SSLError {e}')
         except Exception as e:
-            logger.exception(
-                'Exception while handling connection %r' %
-                self.client.connection, exc_info=e)
+            logger.error('Exception while handling connection %r' % self.client.connection)
         finally:
             self.shutdown()

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -166,8 +166,8 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                     'BrokenPipeError when flushing buffer for server')
                 return True
             except OSError as e:
-                logger.exception(
-                    'OSError when flushing buffer to server', exc_info=e)
+                logger.error(
+                    f'OSError when flushing buffer to server {e}')
                 return True
         return False
 
@@ -198,9 +198,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                 if e.errno == errno.ECONNRESET:
                     logger.warning('Connection reset by upstream: %r' % e)
                 else:
-                    logger.exception(
-                        'Exception while receiving from %s connection %r with reason %r' %
-                        (self.server.tag, self.server.connection, e))
+                    logger.error('Exception while receiving from %s connection %r with reason %r' % (self.server.tag, self.server.connection, e))
                 return True
 
             if raw is None:
@@ -422,7 +420,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                 self.server.closed = True
                 raise ProxyConnectionFailed(text_(host), port, repr(e)) from e
         else:
-            logger.exception('Both host and port must exist')
+            logger.error('Both host and port must exist')
             raise HttpProtocolException()
 
     #
@@ -526,16 +524,16 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
             # sending to client can raise, handle expected exceptions
             self.wrap_client()
         except subprocess.TimeoutExpired as e:  # Popen communicate timeout
-            logger.exception(
-                'TimeoutExpired during certificate generation', exc_info=e)
+            logger.error(
+                f'TimeoutExpired during certificate generation {e}')
             return True
         except BrokenPipeError:
             logger.error(
                 'BrokenPipeError when wrapping client')
             return True
         except OSError as e:
-            logger.exception(
-                'OSError when wrapping client', exc_info=e)
+            logger.error(
+                f'OSError when wrapping client {e}')
             return True
         # Update all plugin connection reference
         # TODO(abhinavsingh): Is this required?

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -532,8 +532,8 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                 'BrokenPipeError when wrapping client')
             return True
         except OSError as e:
-            logger.error(
-                f'OSError when wrapping client {e}')
+            #logger.error(
+            #    f'OSError when wrapping client {e}')
             return True
         # Update all plugin connection reference
         # TODO(abhinavsingh): Is this required?

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -166,7 +166,7 @@ class Proxy:
             input_args = []
 
         if not Proxy.is_py3():
-            print(PY2_DEPRECATION_MESSAGE)
+            #print(PY2_DEPRECATION_MESSAGE)
             sys.exit(1)
 
         # Discover flags from requested plugin.

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -184,6 +184,9 @@ class Proxy:
             sys.exit(0)
 
         # Setup logging module
+        args.log_file  = cast(Optional[str], opts.get('log_file', args.log_file))
+        args.log_level  = cast(Optional[str], opts.get('log_level', args.log_level))
+        args.log_format  = cast(Optional[str], opts.get('log_format', args.log_format))
         Proxy.setup_logger(args.log_file, args.log_level, args.log_format)
 
         # Setup limits


### PR DESCRIPTION
The script wasn't passing log arguments notably: `log_file`, `log_level` and `log_format` from the python interface. In siimple, this wasn't working: 

```python
proxy.main(
    hostname = ipaddress.IPv4Address("127.0.0.1"),
    port = 8080,
    plugins = [],
    log_file = "/tmp/logger.log"
)
```

This pull request fixed this issue. 