### PR TITLE
Fix the `typing_extensions` runtime dependency version

### DIFF
--- a/proxy/common/types.py
+++ b/proxy/common/types.py
@@ -10,10 +10,17 @@
 """
 import queue
 import ipaddress
+import sys
 
 from typing import TYPE_CHECKING, Dict, Any, List, Union
 
-from typing_extensions import Protocol
+# NOTE: Using try/except causes linting problems which is why it's necessary
+# NOTE: to use this mypy/pylint idiom for py36-py38 compatibility
+# Ref: https://github.com/python/typeshed/issues/3500#issuecomment-560958608
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     DictQueueType = queue.Queue[Dict[str, Any]]    # pragma: no cover

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-typing-extensions==3.10.0.2
+typing-extensions==3.10.0.2; python_version < "3.8"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ if __name__ == '__main__':
         zip_safe=False,
         packages=find_packages(exclude=['tests', 'tests.*']),
         package_data={'proxy': ['py.typed']},
-        install_requires=open('requirements.txt', 'r').read().strip().split(),
+        install_requires=[
+            'typing-extensions; python_version < "3.8"',
+        ],
         entry_points={
             'console_scripts': [
                 'proxy = proxy:entry_point'


### PR DESCRIPTION
This patch updates the code to only use `typing-extensions` when the stdlib type is unavailable. It also makes it unpinned in the package metadata (keeping the pins in the test env requirements). This allows it to be used in virtualenvs along with other requirements that have dependencies on `typing-extensions` too.