### PR TITLE
Add a no-op check job to GHA for branch protection

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -116,3 +116,16 @@ jobs:
         --parallel auto
         --parallel-live
         --skip-missing-interpreters false
+
+  check:  # This job does nothing and is only used for the branch protection
+    needs:
+    - build
+    - tox
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Report success of the test matrix
+      run: >-
+        print("All's good")
+      shell: python


### PR DESCRIPTION
This patch adds an "empty" job that depends on all the important ones
making it possible to use just this `check` job in the branch
protection settings. This reduces the maintenance burden by preventing
the need to update these settings on any changes to the job
declarations.