### PR TITLE
Pre-install mypy deps in `pre-commit.ci`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,6 +160,9 @@ repos:
   rev: v0.910
   hooks:
   - id: mypy
+    additional_dependencies:
+    - paramiko == 2.8.0
+    - types-paramiko == 2.7.3
     args:
     # FIXME: get rid of missing imports ignore
     - --ignore-missing-imports


### PR DESCRIPTION
`pre-commit.ci` web-service runs checks in a container with networking disabled. This is why `mypy --install-types` doesn't work there and the additional dependencies need to be declared explicitly. This patch does just that.