### PR TITLE
Make pytest emit XML coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
 # NOTE: `{envpython} -m pytest` because it'd add CWD into $PYTHONPATH
 # NOTE: testing the project from the Git checkout
 # NOTE: rather than one installed.
-commands = pytest --cov=proxy tests/ {posargs:}
+commands = pytest --cov=proxy --cov-report=xml tests/ {posargs:}
 
 
 [dists]


### PR DESCRIPTION
This patch should make GHA report coverage to codecov properly.