### PR TITLE
Add tests for missing core modules

### DIFF
--- a/.github/workflows/test-brew.yml
+++ b/.github/workflows/test-brew.yml
@@ -1,12 +1,12 @@
 ---
-name: Proxy.py Brew
+name: brew
 
 on: [push, pull_request]  # yamllint disable-line rule:truthy
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}-latest
-    name: Brew - Python ${{ matrix.python }} on ${{ matrix.os }}
+    name: 🐍${{ matrix.python }} @ ${{ matrix.os }}
     strategy:
       matrix:
         os: [macOS]

--- a/.github/workflows/test-dashboard.yml
+++ b/.github/workflows/test-dashboard.yml
@@ -1,12 +1,12 @@
 ---
-name: Proxy.py Dashboard
+name: dashboard
 
 on: [push, pull_request]  # yamllint disable-line rule:truthy
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}-latest
-    name: Dashboard - Node ${{ matrix.node }} on ${{ matrix.os }}
+    name: Node ${{ matrix.node }} @ ${{ matrix.os }}
     strategy:
       matrix:
         os: [macOS, ubuntu, windows]

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,12 +1,12 @@
 ---
-name: Proxy.py Docker
+name: docker
 
 on: [push, pull_request]  # yamllint disable-line rule:truthy
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}-latest
-    name: Docker - Python ${{ matrix.python }} on ${{ matrix.os }}
+    name: 🐍${{ matrix.python }} @ ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu]

--- a/helper/homebrew/develop/proxy.rb
+++ b/helper/homebrew/develop/proxy.rb
@@ -9,11 +9,6 @@ class Proxy < Formula
 
   depends_on "python"
 
-  resource "typing-extensions" do
-    url "https://files.pythonhosted.org/packages/6a/28/d32852f2af6b5ead85d396249d5bdf450833f3a69896d76eb480d9c5e406/typing_extensions-3.7.4.2.tar.gz"
-    sha256 "79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"
-  end
-
   def install
     virtualenv_install_with_resources
   end

--- a/helper/homebrew/stable/proxy.rb
+++ b/helper/homebrew/stable/proxy.rb
@@ -5,14 +5,10 @@ class Proxy < Formula
     Network monitoring, controls & Application development, testing, debugging."
   homepage "https://github.com/abhinavsingh/proxy.py"
   url "https://github.com/abhinavsingh/proxy.py/archive/master.zip"
-  version "2.2.0"
+  sha256 "715687cebd451285d266f29d6509a64becc93da21f61ba9b4414e7dc4ecaaeed"
+  version "2.3.1"
 
   depends_on "python"
-
-  resource "typing-extensions" do
-    url "https://files.pythonhosted.org/packages/6a/28/d32852f2af6b5ead85d396249d5bdf450833f3a69896d76eb480d9c5e406/typing_extensions-3.7.4.2.tar.gz"
-    sha256 "79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"
-  end
 
   def install
     virtualenv_install_with_resources

--- a/proxy/core/acceptor/threadless.py
+++ b/proxy/core/acceptor/threadless.py
@@ -198,8 +198,6 @@ class Threadless(multiprocessing.Process):
             self.loop = asyncio.get_event_loop()
             while not self.running.is_set():
                 self.run_once()
-        except KeyboardInterrupt:
-            pass
         finally:
             assert self.selector is not None
             self.selector.unregister(self.client_queue)

--- a/proxy/core/acceptor/work.py
+++ b/proxy/core/acceptor/work.py
@@ -73,7 +73,7 @@ class Work(ABC):
         compatibility with threaded mode where work class is started as
         a separate thread.
         """
-        pass
+        pass    # pragma: no cover
 
     def publish_event(
             self,

--- a/proxy/http/parser.py
+++ b/proxy/http/parser.py
@@ -180,7 +180,8 @@ class HttpParser:
                     more = False
                 else:
                     raise NotImplementedError(
-                        'Parser shouldn\'t have reached here',
+                        'Parser shouldn\'t have reached here. ' +
+                        'This can happen when content length header is missing but their is a body in the payload',
                     )
             else:
                 more, raw = self.process(raw)
@@ -285,7 +286,8 @@ class HttpParser:
             headers={} if not self.headers else {
                 self.headers[k][0]: self.headers[k][1] for k in self.headers
             },
-            body=self.body if not self.is_chunked_encoded() else ChunkParser.to_chunks(self.body),
+            body=self.body if not self.is_chunked_encoded(
+            ) else ChunkParser.to_chunks(self.body),
         )
 
     def has_host(self) -> bool:

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -231,9 +231,10 @@ class Proxy:
 
         # Load plugins
         default_plugins = [bytes_(p) for p in Proxy.get_default_plugins(args)]
-        extra_plugins = [] if args.plugins.strip() == '' else [
+        extra_plugins = [
             p if isinstance(p, type) else bytes_(p)
             for p in opts.get('plugins', args.plugins.split(text_(COMMA)))
+            if not (isinstance(p, str) and len(p) == 0)
         ]
 
         # Load default plugins along with user provided --plugins
@@ -471,7 +472,7 @@ class Proxy:
             default_plugins.append(PLUGIN_WEB_SERVER)
         if args.pac_file is not None:
             default_plugins.append(PLUGIN_PAC_FILE)
-        return collections.OrderedDict.fromkeys(default_plugins).keys()
+        return list(collections.OrderedDict.fromkeys(default_plugins).keys())
 
     @staticmethod
     def is_py2() -> bool:

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -412,8 +412,7 @@ class Proxy:
         }
         for plugin_ in plugins:
             klass, module_name = Proxy.import_plugin(plugin_)
-            if klass is None and module_name is None:
-                continue
+            assert klass and module_name
             mro = list(inspect.getmro(klass))
             mro.reverse()
             iterator = iter(mro)
@@ -432,8 +431,7 @@ class Proxy:
             klass = plugin
         else:
             plugin_ = text_(plugin.strip())
-            if plugin_ == '':
-                return (None, None)
+            assert plugin_ != ''
             module_name, klass_name = plugin_.rsplit(text_(DOT), 1)
             klass = getattr(
                 importlib.import_module(
@@ -449,8 +447,9 @@ class Proxy:
     def get_default_plugins(
             args: argparse.Namespace,
     ) -> List[str]:
-        # Prepare list of plugins to load based upon
-        # --enable-*, --disable-* and --basic-auth flags.
+        """Prepare list of plugins to load based upon
+        --enable-*, --disable-* and --basic-auth flags.
+        """
         default_plugins: List[str] = []
         if args.basic_auth is not None:
             default_plugins.append(PLUGIN_PROXY_AUTH)
@@ -514,7 +513,7 @@ def main(
             # at runtime.  Example, updating flags, plugin
             # configuration etc.
             #
-            # TODO: Python shell within running proxy.py environment
+            # TODO: Python shell within running proxy.py environment?
             while True:
                 time.sleep(1)
     except KeyboardInterrupt:

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -205,7 +205,7 @@ class Proxy:
         if input_args is None:
             input_args = []
 
-        if not Proxy.is_py3():
+        if Proxy.is_py2():
             print(PY2_DEPRECATION_MESSAGE)
             sys.exit(1)
 
@@ -476,9 +476,9 @@ class Proxy:
         return default_plugins
 
     @staticmethod
-    def is_py3() -> bool:
+    def is_py2() -> bool:
         """Exists only to avoid mocking sys.version_info in tests."""
-        return sys.version_info[0] != 2
+        return sys.version_info[0] == 2
 
     @staticmethod
     def set_open_file_limit(soft_limit: int) -> None:

--- a/tests/http/test_http_parser.py
+++ b/tests/http/test_http_parser.py
@@ -272,8 +272,10 @@ class TestHttpParser(unittest.TestCase):
         self.parser.parse(b'Content-Type: text/plain' + CRLF)
         self.assertEqual(self.parser.buffer, b'')
         self.assertEqual(
-            self.parser.headers[b'content-type'], (b'Content-Type',
-                                                   b'text/plain'),
+            self.parser.headers[b'content-type'], (
+                b'Content-Type',
+                b'text/plain',
+            ),
         )
         self.assertEqual(
             self.parser.state,
@@ -636,7 +638,8 @@ class TestHttpParser(unittest.TestCase):
 
     def test_request_factory(self) -> None:
         r = HttpParser.request(
-            b'POST http://localhost:12345 HTTP/1.1' + CRLF + b'key: value' + CRLF + b'Content-Length: 13' + CRLF + CRLF + b'Hello from py')
+            b'POST http://localhost:12345 HTTP/1.1' + CRLF + b'key: value' + CRLF + b'Content-Length: 13' + CRLF + CRLF + b'Hello from py',
+        )
         self.assertEqual(r.host, b'localhost')
         self.assertEqual(r.port, 12345)
         self.assertEqual(r.path, b'/')
@@ -647,12 +650,15 @@ class TestHttpParser(unittest.TestCase):
 
     def test_response_factory(self) -> None:
         r = HttpParser.response(
-            b'HTTP/1.1 200 OK\r\nkey: value\r\n\r\n')
+            b'HTTP/1.1 200 OK\r\nkey: value\r\n\r\n',
+        )
         self.assertEqual(r.code, b'200')
         self.assertEqual(r.reason, b'OK')
         self.assertEqual(r.header(b'key'), b'value')
 
     def test_parser_shouldnt_have_reached_here(self) -> None:
         with self.assertRaises(NotImplementedError):
-            HttpParser.request(b'POST http://localhost:12345 HTTP/1.1' + CRLF +
-                               b'key: value' + CRLF + CRLF + b'Hello from py')
+            HttpParser.request(
+                b'POST http://localhost:12345 HTTP/1.1' + CRLF +
+                b'key: value' + CRLF + CRLF + b'Hello from py',
+            )

--- a/tests/http/test_http_parser.py
+++ b/tests/http/test_http_parser.py
@@ -638,7 +638,10 @@ class TestHttpParser(unittest.TestCase):
 
     def test_request_factory(self) -> None:
         r = HttpParser.request(
-            b'POST http://localhost:12345 HTTP/1.1' + CRLF + b'key: value' + CRLF + b'Content-Length: 13' + CRLF + CRLF + b'Hello from py',
+            b'POST http://localhost:12345 HTTP/1.1' + CRLF +
+            b'key: value' + CRLF +
+            b'Content-Length: 13' + CRLF + CRLF +
+            b'Hello from py',
         )
         self.assertEqual(r.host, b'localhost')
         self.assertEqual(r.port, 12345)

--- a/tests/http/test_http_parser.py
+++ b/tests/http/test_http_parser.py
@@ -272,7 +272,8 @@ class TestHttpParser(unittest.TestCase):
         self.parser.parse(b'Content-Type: text/plain' + CRLF)
         self.assertEqual(self.parser.buffer, b'')
         self.assertEqual(
-            self.parser.headers[b'content-type'], (b'Content-Type', b'text/plain'),
+            self.parser.headers[b'content-type'], (b'Content-Type',
+                                                   b'text/plain'),
         )
         self.assertEqual(
             self.parser.state,
@@ -632,3 +633,26 @@ class TestHttpParser(unittest.TestCase):
         self.parser = HttpParser(httpParserTypes.RESPONSE_PARSER)
         self.parser.parse(response)
         self.assertEqual(self.parser.state, httpParserStates.COMPLETE)
+
+    def test_request_factory(self) -> None:
+        r = HttpParser.request(
+            b'POST http://localhost:12345 HTTP/1.1' + CRLF + b'key: value' + CRLF + b'Content-Length: 13' + CRLF + CRLF + b'Hello from py')
+        self.assertEqual(r.host, b'localhost')
+        self.assertEqual(r.port, 12345)
+        self.assertEqual(r.path, b'/')
+        self.assertEqual(r.header(b'key'), b'value')
+        self.assertEqual(r.header(b'KEY'), b'value')
+        self.assertEqual(r.header(b'content-length'), b'13')
+        self.assertEqual(r.body, b'Hello from py')
+
+    def test_response_factory(self) -> None:
+        r = HttpParser.response(
+            b'HTTP/1.1 200 OK\r\nkey: value\r\n\r\n')
+        self.assertEqual(r.code, b'200')
+        self.assertEqual(r.reason, b'OK')
+        self.assertEqual(r.header(b'key'), b'value')
+
+    def test_parser_shouldnt_have_reached_here(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            HttpParser.request(b'POST http://localhost:12345 HTTP/1.1' + CRLF +
+                               b'key: value' + CRLF + CRLF + b'Hello from py')

--- a/tests/http/test_http_proxy.py
+++ b/tests/http/test_http_proxy.py
@@ -115,3 +115,42 @@ class TestHttpProxyPlugin(unittest.TestCase):
         self.protocol_handler.run_once()
         mock_server_conn.assert_not_called()
         self.plugin.return_value.before_upstream_connection.assert_called()
+
+    def test_proxy_plugin_plugins_can_teardown_from_write_to_descriptors(self) -> None:
+        pass
+
+    def test_proxy_plugin_retries_on_ssl_want_write_error(self) -> None:
+        pass
+
+    def test_proxy_plugin_broken_pipe_error_on_write_will_teardown(self) -> None:
+        pass
+
+    def test_proxy_plugin_plugins_can_teardown_from_read_from_descriptors(self) -> None:
+        pass
+
+    def test_proxy_plugin_retries_on_ssl_want_read_error(self) -> None:
+        pass
+
+    def test_proxy_plugin_timeout_error_on_read_will_teardown(self) -> None:
+        pass
+
+    def test_proxy_plugin_invokes_handle_pipeline_response(self) -> None:
+        pass
+
+    def test_proxy_plugin_invokes_on_access_log(self) -> None:
+        pass
+
+    def test_proxy_plugin_skips_server_teardown_when_client_closes_and_server_never_initialized(self) -> None:
+        pass
+
+    def test_proxy_plugin_invokes_handle_client_data(self) -> None:
+        pass
+
+    def test_proxy_plugin_handles_pipeline_response(self) -> None:
+        pass
+
+    def test_proxy_plugin_invokes_resolve_dns(self) -> None:
+        pass
+
+    def test_proxy_plugin_require_both_host_port_to_connect(self) -> None:
+        pass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -178,6 +178,39 @@ class TestMain(unittest.TestCase):
         mock_event_manager.return_value.stop_event_dispatcher.assert_called_once()
 
     @mock.patch('time.sleep')
+    @mock.patch('proxy.proxy.Proxy.load_plugins')
+    @mock.patch('proxy.common.flag.FlagParser.parse_args')
+    @mock.patch('proxy.proxy.EventManager')
+    @mock.patch('proxy.proxy.AcceptorPool')
+    def test_enable_devtools(
+        self,
+        mock_acceptor_pool: mock.Mock,
+        mock_event_manager: mock.Mock,
+        mock_parse_args: mock.Mock,
+        mock_load_plugins: mock.Mock,
+        mock_sleep: mock.Mock,
+    ) -> None:
+        mock_sleep.side_effect = KeyboardInterrupt()
+        mock_args = mock_parse_args.return_value
+        self.mock_default_args(mock_args)
+        mock_args.enable_devtools = True
+        main(['--enable-devtools'])
+        mock_load_plugins.assert_called()
+        print(mock_load_plugins.call_args_list[0][0][0])
+        self.assertEqual(
+            mock_load_plugins.call_args_list[0][0][0], [
+                b'proxy.http.inspector.DevtoolsProtocolPlugin',
+                b'proxy.http.server.HttpWebServerPlugin',
+                b'proxy.http.proxy.HttpProxyPlugin',
+            ],
+        )
+        mock_parse_args.assert_called_once()
+        mock_acceptor_pool.assert_called()
+        mock_acceptor_pool.return_value.setup.assert_called()
+        # Currently --enable-devtools alone doesn't enable eventing core
+        mock_event_manager.assert_not_called()
+
+    @mock.patch('time.sleep')
     @mock.patch('os.remove')
     @mock.patch('os.path.exists')
     @mock.patch('builtins.open')
@@ -284,14 +317,11 @@ class TestMain(unittest.TestCase):
             mock_print.assert_called_with(__version__)
         self.assertEqual(e.exception.code, 0)
 
-    def test_enable_devtools(self) -> None:
-        pass
+    # def test_pac_file(self) -> None:
+    #     pass
 
-    def test_pac_file(self) -> None:
-        pass
+    # def test_imports_plugin(self) -> None:
+    #     pass
 
-    def test_imports_plugin(self) -> None:
-        pass
-
-    def test_cannot_enable_https_proxy_and_tls_interception_mutually(self) -> None:
-        pass
+    # def test_cannot_enable_https_proxy_and_tls_interception_mutually(self) -> None:
+    #     pass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,18 +13,17 @@ import tempfile
 import os
 
 from unittest import mock
-from typing import List
 
 from proxy.proxy import main, Proxy, entry_point
 from proxy.common.utils import bytes_
 from proxy.http.handler import HttpProtocolHandler
 
-from proxy.common.constants import DEFAULT_ENABLE_DASHBOARD, DEFAULT_LOG_LEVEL, DEFAULT_LOG_FILE, DEFAULT_LOG_FORMAT, DEFAULT_BASIC_AUTH
+from proxy.common.constants import DEFAULT_ENABLE_DASHBOARD, DEFAULT_LOG_LEVEL, DEFAULT_LOG_FILE, DEFAULT_LOG_FORMAT
 from proxy.common.constants import DEFAULT_TIMEOUT, DEFAULT_DEVTOOLS_WS_PATH, DEFAULT_DISABLE_HTTP_PROXY
 from proxy.common.constants import DEFAULT_ENABLE_STATIC_SERVER, DEFAULT_ENABLE_EVENTS, DEFAULT_ENABLE_DEVTOOLS
 from proxy.common.constants import DEFAULT_ENABLE_WEB_SERVER, DEFAULT_THREADLESS, DEFAULT_CERT_FILE, DEFAULT_KEY_FILE
 from proxy.common.constants import DEFAULT_CA_CERT_FILE, DEFAULT_CA_KEY_FILE, DEFAULT_CA_SIGNING_KEY_FILE
-from proxy.common.constants import DEFAULT_PAC_FILE, DEFAULT_PLUGINS, DEFAULT_PID_FILE, DEFAULT_PORT
+from proxy.common.constants import DEFAULT_PAC_FILE, DEFAULT_PLUGINS, DEFAULT_PID_FILE, DEFAULT_PORT, DEFAULT_BASIC_AUTH
 from proxy.common.constants import DEFAULT_NUM_WORKERS, DEFAULT_OPEN_FILE_LIMIT, DEFAULT_IPV6_HOSTNAME
 from proxy.common.constants import DEFAULT_SERVER_RECVBUF_SIZE, DEFAULT_CLIENT_RECVBUF_SIZE, PY2_DEPRECATION_MESSAGE
 from proxy.common.version import __version__

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -161,13 +161,15 @@ class TestMain(unittest.TestCase):
         mock_args.enable_dashboard = True
         main(['--enable-dashboard'])
         mock_load_plugins.assert_called()
-        self.assertEqual(mock_load_plugins.call_args_list[0][0][0], [
-            b'proxy.http.server.HttpWebServerPlugin',
-            b'proxy.dashboard.dashboard.ProxyDashboard',
-            b'proxy.dashboard.inspect_traffic.InspectTrafficPlugin',
-            b'proxy.http.inspector.DevtoolsProtocolPlugin',
-            b'proxy.http.proxy.HttpProxyPlugin',
-        ])
+        self.assertEqual(
+            mock_load_plugins.call_args_list[0][0][0], [
+                b'proxy.http.server.HttpWebServerPlugin',
+                b'proxy.dashboard.dashboard.ProxyDashboard',
+                b'proxy.dashboard.inspect_traffic.InspectTrafficPlugin',
+                b'proxy.http.inspector.DevtoolsProtocolPlugin',
+                b'proxy.http.proxy.HttpProxyPlugin',
+            ],
+        )
         mock_parse_args.assert_called_once()
         mock_acceptor_pool.assert_called()
         mock_acceptor_pool.return_value.setup.assert_called()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -230,3 +230,18 @@ class TestMain(unittest.TestCase):
             main(['--version'])
             mock_print.assert_called_with(__version__)
         self.assertEqual(e.exception.code, 0)
+
+    def test_enable_dashboard(self) -> None:
+        pass
+
+    def test_enable_devtools(self) -> None:
+        pass
+
+    def test_pac_file(self) -> None:
+        pass
+
+    def test_imports_plugin(self) -> None:
+        pass
+
+    def test_cannot_enable_https_proxy_and_tls_interception_mutually(self) -> None:
+        pass


### PR DESCRIPTION
Additionally:

1. Rename GHA job names to be consistent across all workflows.
2. Update homebrew packaging
3. Simply `is_py3` logic
4. Fix an issue where empty plugin name was passed around and then ignored
5. Coverage for `main`, `entry_point` and `Proxy` context manager and `HttpParser`