### PR TITLE
Collect coverage for `tests/`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
 # NOTE: `{envpython} -m pytest` because it'd add CWD into $PYTHONPATH
 # NOTE: testing the project from the Git checkout
 # NOTE: rather than one installed.
-commands = pytest --cov=proxy --cov-report=xml tests/ {posargs:}
+commands = pytest --cov=proxy --cov=tests/ --cov-report=xml tests/ {posargs:}
 
 
 [dists]


### PR DESCRIPTION
This is necessary to make sure all the tests actually get executed
somewhere and allows finding dead code in this area.