### PR TITLE
Ignore a `DeprecationWarning` in `pytest` config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -56,6 +56,9 @@ faulthandler_timeout = 30
 filterwarnings =
   error
 
+  # FIXME: Address the deprecation warning in Python 3.10 and revert this ignore
+  ignore:There is no current event loop:DeprecationWarning:proxy.core.acceptor.threadless
+
 junit_duration_report = call
 # xunit1 contains more metadata than xunit2 so it's better for CI UIs:
 junit_family = xunit1


### PR DESCRIPTION
This was added in Python 3.10 and needs to be dealt with properly.

Action items:
* [ ] Stop calling `asyncio.get_event_loop()` outside of a running event loop
* [ ] Replace it with `asyncio.get_event_loop_policy().get_event_loop()` maybe