### PR TITLE
Pool

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ Looking for `proxy.py` plugin examples?  Check [proxy/plugin](https://github.com
 
 Table of Contents
 =================
+* [Generic Work Acceptor and Executor](#generic-work-acceptor-and-executor)
 * [WebSocket Client](#websocket-client)
 * [TCP Echo Server](#tcp-echo-server)
 * [TCP Echo Client](#tcp-echo-client)
@@ -13,6 +14,17 @@ Table of Contents
 * [SSL Echo Client](#ssl-echo-client)
 * [PubSub Eventing](#pubsub-eventing)
 * [Https Connect Tunnel](#https-connect-tunnel)
+
+## Generic Work Acceptor and Executor
+
+1. Makes use of `proxy.core.AcceptorPool` and `proxy.core.Work`
+2. Demonstrates how to perform generic work using `proxy.py` core.
+
+Start `web_scraper.py` as:
+
+```console
+❯ PYTHONPATH=. python examples/web_scraper.py
+```
 
 ## WebSocket Client
 
@@ -22,7 +34,7 @@ Table of Contents
 
 Start `websocket_client.py` as:
 
-```bash
+```console
 ❯ PYTHONPATH=. python examples/websocket_client.py
 Received b'hello' after 306 millisec
 Received b'hello' after 308 millisec
@@ -44,7 +56,7 @@ Received b'hello' after 309 millisec
 
 Start `tcp_echo_server.py` as:
 
-```bash
+```console
 ❯ PYTHONPATH=. python examples/tcp_echo_server.py
 Connection accepted from ('::1', 53285, 0, 0)
 Connection closed by client ('::1', 53285, 0, 0)
@@ -57,7 +69,7 @@ Connection closed by client ('::1', 53285, 0, 0)
 
 Start `tcp_echo_client.py` as:
 
-```bash
+```console
 ❯ PYTHONPATH=. python examples/tcp_echo_client.py
 b'hello'
 b'hello'
@@ -81,7 +93,7 @@ KeyboardInterrupt
 
 Start `ssl_echo_server.py` as:
 
-```bash
+```console
 ❯ PYTHONPATH=. python examples/ssl_echo_server.py
 ```
 
@@ -92,7 +104,7 @@ Start `ssl_echo_server.py` as:
 
 Start `ssl_echo_client.py` as:
 
-```bash
+```console
 ❯ PYTHONPATH=. python examples/ssl_echo_client.py
 ```
 
@@ -107,7 +119,7 @@ Start `ssl_echo_client.py` as:
 
 Start `pubsub_eventing.py` as:
 
-```bash
+```console
 ❯ PYTHONPATH=. python examples/pubsub_eventing.py
 DEBUG:proxy.core.event.subscriber:Subscribed relay sub id 5eb22010764f4d44900f41e2fb408ca6 from core events
 publisher starting

--- a/examples/web_scraper.py
+++ b/examples/web_scraper.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""
+    proxy.py
+    ~~~~~~~~
+    ⚡⚡⚡ Fast, Lightweight, Pluggable, TLS interception capable proxy server focused on
+    Network monitoring, controls & Application development, testing, debugging.
+
+    :copyright: (c) 2013-present by Abhinav Singh and contributors.
+    :license: BSD, see LICENSE for more details.
+"""
+import time
+import socket
+
+from typing import Dict
+
+from proxy.proxy import Proxy
+from proxy.core.acceptor import Work, AcceptorPool
+from proxy.common.types import Readables, Writables
+
+
+class WebScraper(Work):
+    """Demonstrates how to orchestrate a generic work acceptors and executors
+    workflow using proxy.py core.
+
+    By default, `WebScraper` expects to receive work from a file on disk.
+    Each line in the file must be a URL to scrape.  Received URL is scrapped
+    by the implementation in this class.
+
+    After scrapping, results are published to the eventing core.  One or several
+    result subscriber can then handle the result as necessary.  Currently, result
+    subscribers consume the scrapped response and write discovered URL in the
+    file on the disk.  This creates a feedback loop.  Allowing WebScraper to
+    continue endlessly.
+
+    NOTE: No loop detection is performed currently.
+
+    NOTE: File descriptor need not point to a file on disk.
+    Example, file descriptor can be a database connection.
+    For simplicity, imagine a Redis server connection handling
+    only PUBSUB protocol.
+    """
+
+    def get_events(self) -> Dict[socket.socket, int]:
+        """Return sockets and events (read or write) that we are interested in."""
+        return {}
+
+    def handle_events(
+            self,
+            readables: Readables,
+            writables: Writables,
+    ) -> bool:
+        """Handle readable and writable sockets.
+
+        Return True to shutdown work."""
+        return False
+
+
+if __name__ == '__main__':
+    with AcceptorPool(
+        flags=Proxy.initialize(
+            port=12345,
+            num_workers=1,
+            threadless=True,
+            keyfile='https-key.pem',
+            certfile='https-signed-cert.pem',
+        ),
+        work_klass=WebScraper,
+    ) as pool:
+        while True:
+            time.sleep(1)

--- a/proxy/core/acceptor/acceptor.py
+++ b/proxy/core/acceptor/acceptor.py
@@ -74,17 +74,17 @@ class Acceptor(multiprocessing.Process):
     ) -> None:
         super().__init__()
         self.flags = flags
+        # Eventing core queue
+        self.event_queue = event_queue
+        # Index assigned by `AcceptorPool`
+        self.idd = idd
         # Lock shared by all acceptor processes
         # to avoid concurrent accept over server socket
         self.lock = lock
-        # Index assigned by `AcceptorPool`
-        self.idd = idd
         # Queue over which server socket fd is received on start-up
         self.work_queue: connection.Connection = work_queue
         # Worker class
         self.work_klass = work_klass
-        # Eventing core queue
-        self.event_queue = event_queue
         # Selector & threadless states
         self.running = multiprocessing.Event()
         self.selector: Optional[selectors.DefaultSelector] = None

--- a/proxy/core/acceptor/pool.py
+++ b/proxy/core/acceptor/pool.py
@@ -113,6 +113,7 @@ class AcceptorPool:
         # Override flags.port to match the actual port
         # we are listening upon.  This is necessary to preserve
         # the server port when `--port=0` is used.
+        assert self.socket
         self.flags.port = self.socket.getsockname()[1]
         self._start_acceptors()
         # Send file descriptor to all acceptor processes.

--- a/proxy/core/base/tcp_server.py
+++ b/proxy/core/base/tcp_server.py
@@ -15,8 +15,8 @@ import selectors
 from abc import abstractmethod
 from typing import Dict, Any, Optional
 
-from proxy.core.acceptor import Work
-from proxy.common.types import Readables, Writables
+from ...core.acceptor import Work
+from ...common.types import Readables, Writables
 
 logger = logging.getLogger(__name__)
 

--- a/proxy/core/base/tcp_tunnel.py
+++ b/proxy/core/base/tcp_tunnel.py
@@ -8,9 +8,10 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 """
-from abc import abstractmethod
 import socket
 import selectors
+
+from abc import abstractmethod
 from typing import Any, Optional, Dict
 
 from ...http.parser import HttpParser, httpParserTypes

--- a/proxy/core/connection/__init__.py
+++ b/proxy/core/connection/__init__.py
@@ -11,6 +11,7 @@
 from .connection import TcpConnection, TcpConnectionUninitializedException, tcpConnectionTypes
 from .client import TcpClientConnection
 from .server import TcpServerConnection
+from .pool import ConnectionPool
 
 __all__ = [
     'TcpConnection',
@@ -18,4 +19,5 @@ __all__ = [
     'TcpServerConnection',
     'TcpClientConnection',
     'tcpConnectionTypes',
+    'ConnectionPool',
 ]

--- a/proxy/core/connection/client.py
+++ b/proxy/core/connection/client.py
@@ -22,7 +22,7 @@ class TcpClientConnection(TcpConnection):
         self,
         conn: Union[ssl.SSLSocket, socket.socket],
         addr: Tuple[str, int],
-    ):
+    ) -> None:
         super().__init__(tcpConnectionTypes.CLIENT)
         self._conn: Optional[Union[ssl.SSLSocket, socket.socket]] = conn
         self.addr: Tuple[str, int] = addr

--- a/proxy/core/connection/connection.py
+++ b/proxy/core/connection/connection.py
@@ -101,10 +101,10 @@ class TcpConnection(ABC):
     def is_reusable(self) -> bool:
         return self._reusable
 
-    def mark_inuse(self) -> bool:
+    def mark_inuse(self) -> None:
         self._reusable = False
 
-    def reset(self):
+    def reset(self) -> None:
         assert not self.closed
         self._reusable = True
         self.buffer = []

--- a/proxy/core/connection/connection.py
+++ b/proxy/core/connection/connection.py
@@ -39,12 +39,14 @@ class TcpConnection(ABC):
     when reading and writing into the socket.
 
     Implement the connection property abstract method to return
-    a socket connection object."""
+    a socket connection object.
+    """
 
-    def __init__(self, tag: int):
+    def __init__(self, tag: int) -> None:
+        self.tag: str = 'server' if tag == tcpConnectionTypes.SERVER else 'client'
         self.buffer: List[memoryview] = []
         self.closed: bool = False
-        self.tag: str = 'server' if tag == tcpConnectionTypes.SERVER else 'client'
+        self._reusable: bool = False
 
     @property
     @abstractmethod
@@ -95,3 +97,14 @@ class TcpConnection(ABC):
         del mv
         logger.debug('flushed %d bytes to %s' % (sent, self.tag))
         return sent
+
+    def is_reusable(self) -> bool:
+        return self._reusable
+
+    def mark_inuse(self) -> bool:
+        self._reusable = False
+
+    def reset(self):
+        assert not self.closed
+        self._reusable = True
+        self.buffer = []

--- a/proxy/core/connection/pool.py
+++ b/proxy/core/connection/pool.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+    proxy.py
+    ~~~~~~~~
+    ⚡⚡⚡ Fast, Lightweight, Pluggable, TLS interception capable proxy server focused on
+    Network monitoring, controls & Application development, testing, debugging.
+
+    :copyright: (c) 2013-present by Abhinav Singh and contributors.
+    :license: BSD, see LICENSE for more details.
+"""
+
+
+class ConnectionPool:
+    """Manages connection pool to all upstream servers.
+
+    `ConnectionPool` avoids need to reconnect with the upstream
+    servers repeatedly within the configured expiry time.
+    """
+    pass

--- a/proxy/core/connection/pool.py
+++ b/proxy/core/connection/pool.py
@@ -8,12 +8,62 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 """
+from typing import Set, List, Dict, Tuple
+
+from .server import TcpServerConnection
 
 
 class ConnectionPool:
-    """Manages connection pool to all upstream servers.
+    """Manages connection pool to upstream servers.
 
     `ConnectionPool` avoids need to reconnect with the upstream
-    servers repeatedly within the configured expiry time.
+    servers repeatedly when a reusable connection is available
+    in the pool.
+
+    A separate pool is maintained for each upstream server.
+    So internally, it's a pool of pools.
     """
-    pass
+
+    def __init__(self) -> None:
+        # List of all connection objects
+        #
+        # TODO: Listen for read events from the connections
+        # to remove them from the pool when peer closes the
+        # connection.
+        self.connections: List[TcpServerConnection] = []
+        # Pools of connection per upstream server
+        # Values are list of indexes into the connections list
+        self.pools: Dict[Tuple[str, int], Set[int]] = {}
+
+    def acquire(self, host: str, port: int) -> TcpServerConnection:
+        """Returns a connection for use with the server."""
+        addr = (host, port)
+        # Return a reusable connection if available
+        if addr in self.pools:
+            indexes = self.pools[addr]
+            for index in indexes:
+                if self.connections[index].is_reusable():
+                    self.connections[index].mark_inuse()
+                    return self.connections[index]
+        # Create new connection
+        conn = TcpServerConnection(*addr)
+        self.connections.append(conn)
+        if addr not in self.pools:
+            self.pools[addr] = set()
+        self.pools[addr].add(len(self.connections) - 1)
+        return conn
+
+    def release(self, conn: TcpServerConnection) -> None:
+        """Release the connection.
+
+        If the connection has not been closed,
+        then it will be retained in the pool for reusability.
+        """
+        if conn.closed:
+            # Remove the connection from the pool
+            self.pools[conn.addr].remove(self.connections.index(conn))
+            self.connections.remove(conn)
+        else:
+            assert not conn.is_reusable()
+            # Reset for reusability
+            conn.reset()

--- a/proxy/core/connection/pool.py
+++ b/proxy/core/connection/pool.py
@@ -42,7 +42,7 @@ class ConnectionPool:
         # Pools of connection per upstream server
         self.pools: Dict[Tuple[str, int], Set[TcpServerConnection]] = {}
 
-    def acquire(self, host: str, port: int) -> TcpServerConnection:
+    def acquire(self, host: str, port: int) -> Tuple[bool, TcpServerConnection]:
         """Returns a connection for use with the server."""
         with LOCK:
             addr = (host, port)
@@ -56,7 +56,7 @@ class ConnectionPool:
                                 host, port, id(old_conn),
                             ),
                         )
-                        return old_conn
+                        return False, old_conn
             # Create new connection
             new_conn = TcpServerConnection(*addr)
             if addr not in self.pools:
@@ -67,7 +67,7 @@ class ConnectionPool:
                     host, port, id(new_conn),
                 ),
             )
-            return new_conn
+            return True, new_conn
 
     def release(self, conn: TcpServerConnection) -> None:
         """Release the connection.

--- a/proxy/core/connection/pool.py
+++ b/proxy/core/connection/pool.py
@@ -46,7 +46,7 @@ class ConnectionPool:
     all cores to make SSL session cache to also work
     without additional out-of-bound synchronizations.
 
-    TODO: ConnectionPool currently WONT work for
+    TODO: ConnectionPool currently WON'T work for
     HTTPS connection. This is because of missing support for
     session cache, session ticket, abbr TLS handshake
     and other necessary features to make it work.

--- a/proxy/core/connection/pool.py
+++ b/proxy/core/connection/pool.py
@@ -11,7 +11,7 @@
 import logging
 import multiprocessing
 
-from typing import Set, List, Dict, Tuple
+from typing import Set, Dict, Tuple
 
 from .server import TcpServerConnection
 

--- a/proxy/core/connection/pool.py
+++ b/proxy/core/connection/pool.py
@@ -12,9 +12,18 @@ import logging
 
 from typing import Set, Dict, Tuple
 
+from ...common.flag import flags
 from .server import TcpServerConnection
 
 logger = logging.getLogger(__name__)
+
+
+flags.add_argument(
+    '--enable-conn-pool',
+    action='store_true',
+    default=False,
+    help='Default: False.  (WIP) Enable upstream connection pooling.',
+)
 
 
 class ConnectionPool:

--- a/proxy/core/connection/server.py
+++ b/proxy/core/connection/server.py
@@ -21,7 +21,7 @@ from ...common.utils import new_socket_connection
 class TcpServerConnection(TcpConnection):
     """Establishes connection to upstream server."""
 
-    def __init__(self, host: str, port: int):
+    def __init__(self, host: str, port: int) -> None:
         super().__init__(tcpConnectionTypes.SERVER)
         self._conn: Optional[Union[ssl.SSLSocket, socket.socket]] = None
         self.addr: Tuple[str, int] = (host, int(port))

--- a/proxy/core/connection/server.py
+++ b/proxy/core/connection/server.py
@@ -38,7 +38,7 @@ class TcpServerConnection(TcpConnection):
             self._conn = new_socket_connection(
                 addr or self.addr, source_address=source_address,
             )
-        self.closed = False
+            self.closed = False
 
     def wrap(self, hostname: str, ca_file: Optional[str]) -> None:
         ctx = ssl.create_default_context(

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -180,6 +180,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
         return r, w
 
     def _close_and_release(self) -> bool:
+        assert self.upstream
         self.upstream.closed = True
         self.pool.release(self.upstream)
         return True

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -186,7 +186,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
             self.upstream.closed = True
             with self.lock:
                 self.pool.release(self.upstream)
-        self.upstream = None
+            self.upstream = None
         return True
 
     def write_to_descriptors(self, w: Writables) -> bool:

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -36,8 +36,7 @@ from ...common.utils import build_http_response, text_
 from ...common.pki import gen_public_key, gen_csr, sign_csr
 
 from ...core.event import eventNames
-from ...core.connection import TcpServerConnection, TcpConnectionUninitializedException
-from ...core.connection import ConnectionPool
+from ...core.connection import TcpServerConnection, ConnectionPool
 from ...common.flag import flags
 
 logger = logging.getLogger(__name__)

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -179,7 +179,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
         return r, w
 
     def _close_and_release(self) -> bool:
-        assert self.upstream
+        assert self.upstream and not self.upstream.closed
         self.upstream.closed = True
         self.pool.release(self.upstream)
         return True
@@ -256,7 +256,9 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                         self.upstream.addr,
                     )
                 if e.errno == errno.ECONNRESET:
-                    logger.warning('Connection reset by upstream: %r' % e)
+                    logger.warning(
+                        'Connection reset by upstream: {0}:{1}'.format(*self.upstream.addr),
+                    )
                 else:
                     logger.exception(
                         'Exception while receiving from %s connection %r with reason %r' %

--- a/tests/core/test_conn_pool.py
+++ b/tests/core/test_conn_pool.py
@@ -31,20 +31,18 @@ class TestConnectionPool(unittest.TestCase):
         conn = pool.acquire(*addr)
         mock_tcp_server_connection.assert_called_once_with(*addr)
         self.assertEqual(conn, mock_conn)
-        self.assertEqual(len(pool.connections), 1)
-        self.assertEqual(pool.connections[0], conn)
         self.assertEqual(len(pool.pools[addr]), 1)
-        # Release
+        self.assertTrue(conn in pool.pools[addr])
+        # Release (connection must be retained because not closed)
         pool.release(conn)
-        self.assertEqual(len(pool.connections), 1)
         self.assertEqual(len(pool.pools[addr]), 1)
+        self.assertTrue(conn in pool.pools[addr])
         # Reacquire
         conn = pool.acquire(*addr)
         mock_conn.reset.assert_called_once()
         self.assertEqual(conn, mock_conn)
-        self.assertEqual(len(pool.connections), 1)
-        self.assertEqual(pool.connections[0], conn)
         self.assertEqual(len(pool.pools[addr]), 1)
+        self.assertTrue(conn in pool.pools[addr])
 
     @mock.patch('proxy.core.connection.pool.TcpServerConnection')
     def test_closed_connections_are_removed_on_release(
@@ -60,12 +58,10 @@ class TestConnectionPool(unittest.TestCase):
         conn = pool.acquire(*addr)
         mock_tcp_server_connection.assert_called_once_with(*addr)
         self.assertEqual(conn, mock_conn)
-        self.assertEqual(len(pool.connections), 1)
-        self.assertEqual(pool.connections[0], conn)
         self.assertEqual(len(pool.pools[addr]), 1)
+        self.assertTrue(conn in pool.pools[addr])
         # Release
         pool.release(conn)
-        self.assertEqual(len(pool.connections), 0)
         self.assertEqual(len(pool.pools[addr]), 0)
         # Acquire
         conn = pool.acquire(*addr)

--- a/tests/core/test_conn_pool.py
+++ b/tests/core/test_conn_pool.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+    proxy.py
+    ~~~~~~~~
+    ⚡⚡⚡ Fast, Lightweight, Pluggable, TLS interception capable proxy server focused on
+    Network monitoring, controls & Application development, testing, debugging.
+
+    :copyright: (c) 2013-present by Abhinav Singh and contributors.
+    :license: BSD, see LICENSE for more details.
+"""
+import unittest
+
+from unittest import mock
+
+from proxy.core.connection import ConnectionPool
+
+
+class TestConnectionPool(unittest.TestCase):
+
+    @mock.patch('proxy.core.connection.pool.TcpServerConnection')
+    def test_acquire_and_release_and_reacquire(self, mock_tcp_server_connection: mock.Mock) -> None:
+        pool = ConnectionPool()
+        addr = ('localhost', 1234)
+        # Mock
+        mock_conn = mock_tcp_server_connection.return_value
+        mock_conn.is_reusable.side_effect = [
+            False, True, True,
+        ]
+        mock_conn.closed = False
+        # Acquire
+        conn = pool.acquire(*addr)
+        mock_tcp_server_connection.assert_called_once_with(*addr)
+        self.assertEqual(conn, mock_conn)
+        self.assertEqual(len(pool.connections), 1)
+        self.assertEqual(pool.connections[0], conn)
+        self.assertEqual(len(pool.pools[addr]), 1)
+        # Release
+        pool.release(conn)
+        self.assertEqual(len(pool.connections), 1)
+        self.assertEqual(len(pool.pools[addr]), 1)
+        # Reacquire
+        conn = pool.acquire(*addr)
+        mock_conn.reset.assert_called_once()
+        self.assertEqual(conn, mock_conn)
+        self.assertEqual(len(pool.connections), 1)
+        self.assertEqual(pool.connections[0], conn)
+        self.assertEqual(len(pool.pools[addr]), 1)
+
+    @mock.patch('proxy.core.connection.pool.TcpServerConnection')
+    def test_closed_connections_are_removed_on_release(
+            self, mock_tcp_server_connection: mock.Mock) -> None:
+        pool = ConnectionPool()
+        addr = ('localhost', 1234)
+        # Mock
+        mock_conn = mock_tcp_server_connection.return_value
+        mock_conn.closed = True
+        mock_conn.addr = addr
+        # Acquire
+        conn = pool.acquire(*addr)
+        mock_tcp_server_connection.assert_called_once_with(*addr)
+        self.assertEqual(conn, mock_conn)
+        self.assertEqual(len(pool.connections), 1)
+        self.assertEqual(pool.connections[0], conn)
+        self.assertEqual(len(pool.pools[addr]), 1)
+        # Release
+        pool.release(conn)
+        self.assertEqual(len(pool.connections), 0)
+        self.assertEqual(len(pool.pools[addr]), 0)
+        # Acquire
+        conn = pool.acquire(*addr)
+        self.assertEqual(mock_tcp_server_connection.call_count, 2)
+        mock_conn.is_reusable.assert_not_called()

--- a/tests/core/test_conn_pool.py
+++ b/tests/core/test_conn_pool.py
@@ -48,7 +48,8 @@ class TestConnectionPool(unittest.TestCase):
 
     @mock.patch('proxy.core.connection.pool.TcpServerConnection')
     def test_closed_connections_are_removed_on_release(
-            self, mock_tcp_server_connection: mock.Mock) -> None:
+            self, mock_tcp_server_connection: mock.Mock,
+    ) -> None:
         pool = ConnectionPool()
         addr = ('localhost', 1234)
         # Mock

--- a/tests/core/test_conn_pool.py
+++ b/tests/core/test_conn_pool.py
@@ -28,7 +28,8 @@ class TestConnectionPool(unittest.TestCase):
         ]
         mock_conn.closed = False
         # Acquire
-        conn = pool.acquire(*addr)
+        created, conn = pool.acquire(*addr)
+        self.assertTrue(created)
         mock_tcp_server_connection.assert_called_once_with(*addr)
         self.assertEqual(conn, mock_conn)
         self.assertEqual(len(pool.pools[addr]), 1)
@@ -38,7 +39,8 @@ class TestConnectionPool(unittest.TestCase):
         self.assertEqual(len(pool.pools[addr]), 1)
         self.assertTrue(conn in pool.pools[addr])
         # Reacquire
-        conn = pool.acquire(*addr)
+        created, conn = pool.acquire(*addr)
+        self.assertFalse(created)
         mock_conn.reset.assert_called_once()
         self.assertEqual(conn, mock_conn)
         self.assertEqual(len(pool.pools[addr]), 1)
@@ -55,7 +57,8 @@ class TestConnectionPool(unittest.TestCase):
         mock_conn.closed = True
         mock_conn.addr = addr
         # Acquire
-        conn = pool.acquire(*addr)
+        created, conn = pool.acquire(*addr)
+        self.assertTrue(created)
         mock_tcp_server_connection.assert_called_once_with(*addr)
         self.assertEqual(conn, mock_conn)
         self.assertEqual(len(pool.pools[addr]), 1)
@@ -64,6 +67,7 @@ class TestConnectionPool(unittest.TestCase):
         pool.release(conn)
         self.assertEqual(len(pool.pools[addr]), 0)
         # Acquire
-        conn = pool.acquire(*addr)
+        created, conn = pool.acquire(*addr)
+        self.assertTrue(created)
         self.assertEqual(mock_tcp_server_connection.call_count, 2)
         mock_conn.is_reusable.assert_not_called()


### PR DESCRIPTION
There are significant performance gain when `ConnectionPool` is used for upstream connection pooling.  Below in the screenshot view the timing difference new (0.742s) VS reused (0.334s) connection response time.

However, `ConnectionPool` doesn't support HTTPS connections yet.  This is due to lack of TLS session cache, ticket management.  Till then `ConnectionPool` can be utilized in scenarios where `HTTP` is the only upstream connection mode within the environment.  Example, within `ProxyPool` plugin which talks to `HTTP` only upstream proxies.

<img width="900" alt="Screen Shot 2021-11-07 at 8 22 37 AM" src="https://user-images.githubusercontent.com/126065/140631043-66d45b53-a759-4e6b-ad91-0ab75fc21b75.png">
