### PR TITLE
Top-level notion of work not client

### DIFF
--- a/examples/https_connect_tunnel.py
+++ b/examples/https_connect_tunnel.py
@@ -53,7 +53,7 @@ class HttpsConnectTunnelHandler(BaseTcpTunnelHandler):
 
         # Drop the request if not a CONNECT request
         if self.request.method != httpMethods.CONNECT:
-            self.client.queue(
+            self.work.queue(
                 HttpsConnectTunnelHandler.PROXY_TUNNEL_UNSUPPORTED_SCHEME,
             )
             return True
@@ -66,7 +66,7 @@ class HttpsConnectTunnelHandler(BaseTcpTunnelHandler):
         self.connect_upstream()
 
         # Queue tunnel established response to client
-        self.client.queue(
+        self.work.queue(
             HttpsConnectTunnelHandler.PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT,
         )
 

--- a/examples/ssl_echo_server.py
+++ b/examples/ssl_echo_server.py
@@ -27,19 +27,19 @@ class EchoSSLServerHandler(BaseTcpServerHandler):
         # here using wrap_socket() utility.
         assert self.flags.keyfile is not None and self.flags.certfile is not None
         conn = wrap_socket(
-            self.client.connection,
+            self.work.connection,
             self.flags.keyfile,
             self.flags.certfile,
         )
         conn.setblocking(False)
         # Upgrade plain TcpClientConnection to SSL connection object
-        self.client = TcpClientConnection(
-            conn=conn, addr=self.client.addr,
+        self.work = TcpClientConnection(
+            conn=conn, addr=self.work.addr,
         )
 
     def handle_data(self, data: memoryview) -> Optional[bool]:
         # echo back to client
-        self.client.queue(data)
+        self.work.queue(data)
         return None
 
 

--- a/examples/tcp_echo_server.py
+++ b/examples/tcp_echo_server.py
@@ -20,11 +20,11 @@ class EchoServerHandler(BaseTcpServerHandler):
     """Sets client socket to non-blocking during initialization."""
 
     def initialize(self) -> None:
-        self.client.connection.setblocking(False)
+        self.work.connection.setblocking(False)
 
     def handle_data(self, data: memoryview) -> Optional[bool]:
         # echo back to client
-        self.client.queue(data)
+        self.work.queue(data)
         return None
 
 

--- a/proxy/core/acceptor/work.py
+++ b/proxy/core/acceptor/work.py
@@ -25,15 +25,18 @@ class Work(ABC):
 
     def __init__(
             self,
-            client: TcpClientConnection,
+            work: TcpClientConnection,
             flags: argparse.Namespace,
             event_queue: Optional[EventQueue] = None,
             uid: Optional[UUID] = None,
     ) -> None:
-        self.client = client
-        self.flags = flags
-        self.event_queue = event_queue
+        # Work uuid
         self.uid: UUID = uid if uid is not None else uuid4()
+        self.flags = flags
+        # Eventing core queue
+        self.event_queue = event_queue
+        # Accept work
+        self.work = work
 
     @abstractmethod
     def get_events(self) -> Dict[socket.socket, int]:

--- a/proxy/core/base/tcp_tunnel.py
+++ b/proxy/core/base/tcp_tunnel.py
@@ -43,7 +43,7 @@ class BaseTcpTunnelHandler(BaseTcpServerHandler):
         pass    # pragma: no cover
 
     def initialize(self) -> None:
-        self.client.connection.setblocking(False)
+        self.work.connection.setblocking(False)
 
     def shutdown(self) -> None:
         if self.upstream:
@@ -87,7 +87,7 @@ class BaseTcpTunnelHandler(BaseTcpServerHandler):
                 print('Connection closed by server')
                 return True
             # tunnel data to client
-            self.client.queue(data)
+            self.work.queue(data)
         if self.upstream and self.upstream.connection in writables:
             self.upstream.flush()
         return False

--- a/tests/http/exceptions/test_http_proxy_auth_failed.py
+++ b/tests/http/exceptions/test_http_proxy_auth_failed.py
@@ -63,9 +63,9 @@ class TestHttpProxyAuthFailed(unittest.TestCase):
 
         self.protocol_handler._run_once()
         mock_server_conn.assert_not_called()
-        self.assertEqual(self.protocol_handler.client.has_buffer(), True)
+        self.assertEqual(self.protocol_handler.work.has_buffer(), True)
         self.assertEqual(
-            self.protocol_handler.client.buffer[0], ProxyAuthenticationFailed.RESPONSE_PKT,
+            self.protocol_handler.work.buffer[0], ProxyAuthenticationFailed.RESPONSE_PKT,
         )
         self._conn.send.assert_not_called()
 
@@ -92,9 +92,9 @@ class TestHttpProxyAuthFailed(unittest.TestCase):
 
         self.protocol_handler._run_once()
         mock_server_conn.assert_not_called()
-        self.assertEqual(self.protocol_handler.client.has_buffer(), True)
+        self.assertEqual(self.protocol_handler.work.has_buffer(), True)
         self.assertEqual(
-            self.protocol_handler.client.buffer[0], ProxyAuthenticationFailed.RESPONSE_PKT,
+            self.protocol_handler.work.buffer[0], ProxyAuthenticationFailed.RESPONSE_PKT,
         )
         self._conn.send.assert_not_called()
 
@@ -121,7 +121,7 @@ class TestHttpProxyAuthFailed(unittest.TestCase):
 
         self.protocol_handler._run_once()
         mock_server_conn.assert_called_once()
-        self.assertEqual(self.protocol_handler.client.has_buffer(), False)
+        self.assertEqual(self.protocol_handler.work.has_buffer(), False)
 
     @mock.patch('proxy.http.proxy.server.TcpServerConnection')
     def test_proxy_auth_works_with_mixed_case_basic_string(self, mock_server_conn: mock.Mock) -> None:
@@ -146,4 +146,4 @@ class TestHttpProxyAuthFailed(unittest.TestCase):
 
         self.protocol_handler._run_once()
         mock_server_conn.assert_called_once()
-        self.assertEqual(self.protocol_handler.client.has_buffer(), False)
+        self.assertEqual(self.protocol_handler.work.has_buffer(), False)

--- a/tests/http/test_http_proxy_tls_interception.py
+++ b/tests/http/test_http_proxy_tls_interception.py
@@ -201,7 +201,7 @@ class TestHttpProxyTlsInterception(unittest.TestCase):
         )
         self.assertEqual(self._conn.setblocking.call_count, 2)
         self.assertEqual(
-            self.protocol_handler.client.connection,
+            self.protocol_handler.work.connection,
             self.mock_ssl_wrap.return_value,
         )
 

--- a/tests/http/test_protocol_handler.py
+++ b/tests/http/test_protocol_handler.py
@@ -102,7 +102,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
             ).upstream is not None,
         )
         self.assertEqual(
-            self.protocol_handler.client.buffer[0],
+            self.protocol_handler.work.buffer[0],
             HttpProxyPlugin.PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT,
         )
         mock_server_connection.assert_called_once()
@@ -111,7 +111,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
         server.closed = False
 
         parser = HttpParser(httpParserTypes.RESPONSE_PARSER)
-        parser.parse(self.protocol_handler.client.buffer[0].tobytes())
+        parser.parse(self.protocol_handler.work.buffer[0].tobytes())
         self.assertEqual(parser.state, httpParserStates.COMPLETE)
         assert parser.code is not None
         self.assertEqual(int(parser.code), 200)
@@ -199,7 +199,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
         ])
         self.protocol_handler._run_once()
         self.assertEqual(
-            self.protocol_handler.client.buffer[0],
+            self.protocol_handler.work.buffer[0],
             ProxyConnectionFailed.RESPONSE_PKT,
         )
 
@@ -231,7 +231,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
         ])
         self.protocol_handler._run_once()
         self.assertEqual(
-            self.protocol_handler.client.buffer[0],
+            self.protocol_handler.work.buffer[0],
             ProxyAuthenticationFailed.RESPONSE_PKT,
         )
 
@@ -328,7 +328,7 @@ class TestHttpProtocolHandler(unittest.TestCase):
             CRLF,
         ])
         self.assert_tunnel_response(mock_server_connection, server)
-        self.protocol_handler.client.flush()
+        self.protocol_handler.work.flush()
         self.assert_data_queued_to_server(server)
 
         self.protocol_handler._run_once()

--- a/tests/http/test_web_server.py
+++ b/tests/http/test_web_server.py
@@ -132,7 +132,7 @@ class TestWebServerPlugin(unittest.TestCase):
             httpParserStates.COMPLETE,
         )
         self.assertEqual(
-            self.protocol_handler.client.buffer[0],
+            self.protocol_handler.work.buffer[0],
             HttpWebServerPlugin.DEFAULT_404_RESPONSE,
         )
 

--- a/tests/plugin/test_http_proxy_plugins.py
+++ b/tests/plugin/test_http_proxy_plugins.py
@@ -139,7 +139,7 @@ class TestHttpProxyPluginExamples(unittest.TestCase):
 
         mock_server_conn.assert_not_called()
         self.assertEqual(
-            self.protocol_handler.client.buffer[0].tobytes(),
+            self.protocol_handler.work.buffer[0].tobytes(),
             build_http_response(
                 httpStatusCodes.OK, reason=b'OK',
                 headers={b'Content-Type': b'application/json'},
@@ -215,7 +215,7 @@ class TestHttpProxyPluginExamples(unittest.TestCase):
 
         mock_server_conn.assert_not_called()
         self.assertEqual(
-            self.protocol_handler.client.buffer[0].tobytes(),
+            self.protocol_handler.work.buffer[0].tobytes(),
             build_http_response(
                 status_code=httpStatusCodes.I_AM_A_TEAPOT,
                 reason=b'I\'m a tea pot',
@@ -305,7 +305,7 @@ class TestHttpProxyPluginExamples(unittest.TestCase):
             )
         self.protocol_handler._run_once()
         self.assertEqual(
-            self.protocol_handler.client.buffer[0].tobytes(),
+            self.protocol_handler.work.buffer[0].tobytes(),
             build_http_response(
                 httpStatusCodes.OK,
                 reason=b'OK', body=b'Hello from man in the middle',
@@ -337,7 +337,7 @@ class TestHttpProxyPluginExamples(unittest.TestCase):
         self.protocol_handler._run_once()
 
         self.assertEqual(
-            self.protocol_handler.client.buffer[0].tobytes(),
+            self.protocol_handler.work.buffer[0].tobytes(),
             build_http_response(
                 status_code=httpStatusCodes.NOT_FOUND,
                 reason=b'Blocked',

--- a/tests/plugin/test_http_proxy_plugins_with_tls_interception.py
+++ b/tests/plugin/test_http_proxy_plugins_with_tls_interception.py
@@ -170,14 +170,14 @@ class TestHttpProxyPluginExamplesWithTlsInterception(unittest.TestCase):
         self.mock_server_conn.assert_called_once_with('uni.corn', 443)
         self.server.connect.assert_called()
         self.assertEqual(
-            self.protocol_handler.client.connection,
+            self.protocol_handler.work.connection,
             self.client_ssl_connection,
         )
         self.assertEqual(self.server.connection, self.server_ssl_connection)
         self._conn.send.assert_called_with(
             HttpProxyPlugin.PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT,
         )
-        self.assertFalse(self.protocol_handler.client.has_buffer())
+        self.assertFalse(self.protocol_handler.work.has_buffer())
 
     def test_modify_post_data_plugin(self) -> None:
         original = b'{"key": "value"}'
@@ -229,7 +229,7 @@ class TestHttpProxyPluginExamplesWithTlsInterception(unittest.TestCase):
             )
         self.protocol_handler._run_once()
         self.assertEqual(
-            self.protocol_handler.client.buffer[0].tobytes(),
+            self.protocol_handler.work.buffer[0].tobytes(),
             build_http_response(
                 httpStatusCodes.OK,
                 reason=b'OK', body=b'Hello from man in the middle',


### PR DESCRIPTION
This is a renaming of `Work.client` attribute to `Work.work`.  Idea is that at the top-level, within the `Work` class, context about Tcp client should not be mixed.  Of-course, currently `work` is a `TcpClientConnection` instance but that will be abstracted out later to make `work` a generically accepted work object.