### PR TITLE
Add `--auth-plugin` flag to override default basic auth plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1945,23 +1945,20 @@ for list of tests.
 
 ```console
 ❯ proxy -h
-usage: proxy [-h] [--enable-events] [--enable-conn-pool] [--threadless] [--threaded]
-          [--num-workers NUM_WORKERS] [--backlog BACKLOG] [--hostname HOSTNAME]
-          [--port PORT] [--unix-socket-path UNIX_SOCKET_PATH]
-          [--num-acceptors NUM_ACCEPTORS] [--version] [--log-level LOG_LEVEL]
-          [--log-file LOG_FILE] [--log-format LOG_FORMAT]
+usage: -m [-h] [--enable-events] [--enable-conn-pool] [--threadless] [--threaded]
+          [--num-workers NUM_WORKERS] [--backlog BACKLOG] [--hostname HOSTNAME] [--port PORT]
+          [--unix-socket-path UNIX_SOCKET_PATH] [--num-acceptors NUM_ACCEPTORS] [--version]
+          [--log-level LOG_LEVEL] [--log-file LOG_FILE] [--log-format LOG_FORMAT]
           [--open-file-limit OPEN_FILE_LIMIT] [--plugins PLUGINS [PLUGINS ...]]
           [--enable-dashboard] [--work-klass WORK_KLASS] [--pid-file PID_FILE]
-          [--client-recvbuf-size CLIENT_RECVBUF_SIZE] [--key-file KEY_FILE]
-          [--timeout TIMEOUT] [--disable-http-proxy] [--ca-key-file CA_KEY_FILE]
-          [--ca-cert-dir CA_CERT_DIR] [--ca-cert-file CA_CERT_FILE]
-          [--ca-file CA_FILE] [--ca-signing-key-file CA_SIGNING_KEY_FILE]
-          [--cert-file CERT_FILE] [--disable-headers DISABLE_HEADERS]
-          [--server-recvbuf-size SERVER_RECVBUF_SIZE] [--basic-auth BASIC_AUTH]
-          [--cache-dir CACHE_DIR]
-          [--filtered-upstream-hosts FILTERED_UPSTREAM_HOSTS]
-          [--enable-web-server] [--enable-static-server]
-          [--static-server-dir STATIC_SERVER_DIR]
+          [--client-recvbuf-size CLIENT_RECVBUF_SIZE] [--key-file KEY_FILE] [--timeout TIMEOUT]
+          [--server-recvbuf-size SERVER_RECVBUF_SIZE] [--disable-http-proxy]
+          [--disable-headers DISABLE_HEADERS] [--ca-key-file CA_KEY_FILE]
+          [--ca-cert-dir CA_CERT_DIR] [--ca-cert-file CA_CERT_FILE] [--ca-file CA_FILE]
+          [--ca-signing-key-file CA_SIGNING_KEY_FILE] [--cert-file CERT_FILE]
+          [--auth-plugin AUTH_PLUGIN] [--basic-auth BASIC_AUTH] [--cache-dir CACHE_DIR]
+          [--filtered-upstream-hosts FILTERED_UPSTREAM_HOSTS] [--enable-web-server]
+          [--enable-static-server] [--static-server-dir STATIC_SERVER_DIR]
           [--min-compression-length MIN_COMPRESSION_LENGTH] [--pac-file PAC_FILE]
           [--pac-file-url-path PAC_FILE_URL_PATH] [--proxy-pool PROXY_POOL]
           [--filtered-client-ips FILTERED_CLIENT_IPS]
@@ -1972,131 +1969,120 @@ proxy.py v2.4.0
 
 options:
   -h, --help            show this help message and exit
-  --enable-events       Default: False. Enables core to dispatch lifecycle
-                        events. Plugins can be used to subscribe for core events.
+  --enable-events       Default: False. Enables core to dispatch lifecycle events. Plugins can
+                        be used to subscribe for core events.
   --enable-conn-pool    Default: False. (WIP) Enable upstream connection pooling.
-  --threadless          Default: True. Enabled by default on Python 3.8+ (mac,
-                        linux). When disabled a new thread is spawned to handle
-                        each client connection.
-  --threaded            Default: False. Disabled by default on Python < 3.8 and
-                        windows. When enabled a new thread is spawned to handle
-                        each client connection.
+  --threadless          Default: True. Enabled by default on Python 3.8+ (mac, linux). When
+                        disabled a new thread is spawned to handle each client connection.
+  --threaded            Default: False. Disabled by default on Python < 3.8 and windows. When
+                        enabled a new thread is spawned to handle each client connection.
   --num-workers NUM_WORKERS
                         Defaults to number of CPU cores.
-  --backlog BACKLOG     Default: 100. Maximum number of pending connections to
-                        proxy server
+  --backlog BACKLOG     Default: 100. Maximum number of pending connections to proxy server
   --hostname HOSTNAME   Default: ::1. Server IP address.
   --port PORT           Default: 8899. Server port.
   --unix-socket-path UNIX_SOCKET_PATH
-                        Default: None. Unix socket path to use. When provided
-                        --host and --port flags are ignored
+                        Default: None. Unix socket path to use. When provided --host and --port
+                        flags are ignored
   --num-acceptors NUM_ACCEPTORS
                         Defaults to number of CPU cores.
   --version, -v         Prints proxy.py version.
   --log-level LOG_LEVEL
-                        Valid options: DEBUG, INFO (default), WARNING, ERROR,
-                        CRITICAL. Both upper and lowercase values are allowed.
-                        You may also simply use the leading character e.g. --log-
-                        level d
+                        Valid options: DEBUG, INFO (default), WARNING, ERROR, CRITICAL. Both
+                        upper and lowercase values are allowed. You may also simply use the
+                        leading character e.g. --log-level d
   --log-file LOG_FILE   Default: sys.stdout. Log file destination.
   --log-format LOG_FORMAT
                         Log format for Python logger.
   --open-file-limit OPEN_FILE_LIMIT
-                        Default: 1024. Maximum number of files (TCP connections)
-                        that proxy.py can open concurrently.
+                        Default: 1024. Maximum number of files (TCP connections) that proxy.py
+                        can open concurrently.
   --plugins PLUGINS [PLUGINS ...]
-                        Comma separated plugins. You may use --plugins flag
-                        multiple times.
+                        Comma separated plugins. You may use --plugins flag multiple times.
   --enable-dashboard    Default: False. Enables proxy.py dashboard.
   --work-klass WORK_KLASS
-                        Default: proxy.http.HttpProtocolHandler. Work klass to
-                        use for work execution.
+                        Default: proxy.http.HttpProtocolHandler. Work klass to use for work
+                        execution.
   --pid-file PID_FILE   Default: None. Save "parent" process ID to a file.
   --client-recvbuf-size CLIENT_RECVBUF_SIZE
-                        Default: 1 MB. Maximum amount of data received from the
-                        client in a single recv() operation. Bump this value for
-                        faster uploads at the expense of increased RAM.
-  --key-file KEY_FILE   Default: None. Server key file to enable end-to-end TLS
-                        encryption with clients. If used, must also pass --cert-
-                        file.
-  --timeout TIMEOUT     Default: 10.0. Number of seconds after which an inactive
-                        connection must be dropped. Inactivity is defined by no
-                        data sent or received by the client.
-  --disable-http-proxy  Default: False. Whether to disable proxy.HttpProxyPlugin.
-  --ca-key-file CA_KEY_FILE
-                        Default: None. CA key to use for signing dynamically
-                        generated HTTPS certificates. If used, must also pass
-                        --ca-cert-file and --ca-signing-key-file
-  --ca-cert-dir CA_CERT_DIR
-                        Default: ~/.proxy.py. Directory to store dynamically
-                        generated certificates. Also see --ca-key-file, --ca-
-                        cert-file and --ca-signing-key-file
-  --ca-cert-file CA_CERT_FILE
-                        Default: None. Signing certificate to use for signing
-                        dynamically generated HTTPS certificates. If used, must
-                        also pass --ca-key-file and --ca-signing-key-file
-  --ca-file CA_FILE     Default: /Users/abhinavsingh/Dev/proxy.py/venv310/lib/pyt
-                        hon3.10/site-packages/certifi/cacert.pem. Provide path to
-                        custom CA bundle for peer certificate verification
-  --ca-signing-key-file CA_SIGNING_KEY_FILE
-                        Default: None. CA signing key to use for dynamic
-                        generation of HTTPS certificates. If used, must also pass
-                        --ca-key-file and --ca-cert-file
-  --cert-file CERT_FILE
-                        Default: None. Server certificate to enable end-to-end
-                        TLS encryption with clients. If used, must also pass
-                        --key-file.
-  --disable-headers DISABLE_HEADERS
-                        Default: None. Comma separated list of headers to remove
-                        before dispatching client request to upstream server.
+                        Default: 1 MB. Maximum amount of data received from the client in a
+                        single recv() operation. Bump this value for faster uploads at the
+                        expense of increased RAM.
+  --key-file KEY_FILE   Default: None. Server key file to enable end-to-end TLS encryption with
+                        clients. If used, must also pass --cert-file.
+  --timeout TIMEOUT     Default: 10.0. Number of seconds after which an inactive connection must
+                        be dropped. Inactivity is defined by no data sent or received by the
+                        client.
   --server-recvbuf-size SERVER_RECVBUF_SIZE
-                        Default: 1 MB. Maximum amount of data received from the
-                        server in a single recv() operation. Bump this value for
-                        faster downloads at the expense of increased RAM.
+                        Default: 1 MB. Maximum amount of data received from the server in a
+                        single recv() operation. Bump this value for faster downloads at the
+                        expense of increased RAM.
+  --disable-http-proxy  Default: False. Whether to disable proxy.HttpProxyPlugin.
+  --disable-headers DISABLE_HEADERS
+                        Default: None. Comma separated list of headers to remove before
+                        dispatching client request to upstream server.
+  --ca-key-file CA_KEY_FILE
+                        Default: None. CA key to use for signing dynamically generated HTTPS
+                        certificates. If used, must also pass --ca-cert-file and --ca-signing-
+                        key-file
+  --ca-cert-dir CA_CERT_DIR
+                        Default: ~/.proxy.py. Directory to store dynamically generated
+                        certificates. Also see --ca-key-file, --ca-cert-file and --ca-signing-
+                        key-file
+  --ca-cert-file CA_CERT_FILE
+                        Default: None. Signing certificate to use for signing dynamically
+                        generated HTTPS certificates. If used, must also pass --ca-key-file and
+                        --ca-signing-key-file
+  --ca-file CA_FILE     Default: /Users/abhinavsingh/Dev/proxy.py/venv310/lib/python3.10/site-
+                        packages/certifi/cacert.pem. Provide path to custom CA bundle for peer
+                        certificate verification
+  --ca-signing-key-file CA_SIGNING_KEY_FILE
+                        Default: None. CA signing key to use for dynamic generation of HTTPS
+                        certificates. If used, must also pass --ca-key-file and --ca-cert-file
+  --cert-file CERT_FILE
+                        Default: None. Server certificate to enable end-to-end TLS encryption
+                        with clients. If used, must also pass --key-file.
+  --auth-plugin AUTH_PLUGIN
+                        Default: proxy.http.proxy.AuthPlugin. Auth plugin to use instead of
+                        default basic auth plugin.
   --basic-auth BASIC_AUTH
-                        Default: No authentication. Specify colon separated
-                        user:password to enable basic authentication.
+                        Default: No authentication. Specify colon separated user:password to
+                        enable basic authentication.
   --cache-dir CACHE_DIR
-                        Default: A temporary directory. Flag only applicable when
-                        cache plugin is used with on-disk storage.
+                        Default: A temporary directory. Flag only applicable when cache plugin
+                        is used with on-disk storage.
   --filtered-upstream-hosts FILTERED_UPSTREAM_HOSTS
-                        Default: Blocks Facebook. Comma separated list of IPv4
-                        and IPv6 addresses.
-  --enable-web-server   Default: False. Whether to enable
-                        proxy.HttpWebServerPlugin.
+                        Default: Blocks Facebook. Comma separated list of IPv4 and IPv6
+                        addresses.
+  --enable-web-server   Default: False. Whether to enable proxy.HttpWebServerPlugin.
   --enable-static-server
-                        Default: False. Enable inbuilt static file server.
-                        Optionally, also use --static-server-dir to serve static
-                        content from custom directory. By default, static file
-                        server serves out of installed proxy.py python module
-                        folder.
+                        Default: False. Enable inbuilt static file server. Optionally, also use
+                        --static-server-dir to serve static content from custom directory. By
+                        default, static file server serves out of installed proxy.py python
+                        module folder.
   --static-server-dir STATIC_SERVER_DIR
-                        Default: "public" folder in directory where proxy.py is
-                        placed. This option is only applicable when static server
-                        is also enabled. See --enable-static-server.
+                        Default: "public" folder in directory where proxy.py is placed. This
+                        option is only applicable when static server is also enabled. See
+                        --enable-static-server.
   --min-compression-length MIN_COMPRESSION_LENGTH
-                        Default: 20 bytes. Sets the minimum length of a response
-                        that will be compressed (gzipped).
-  --pac-file PAC_FILE   A file (Proxy Auto Configuration) or string to serve when
-                        the server receives a direct file request. Using this
-                        option enables proxy.HttpWebServerPlugin.
+                        Default: 20 bytes. Sets the minimum length of a response that will be
+                        compressed (gzipped).
+  --pac-file PAC_FILE   A file (Proxy Auto Configuration) or string to serve when the server
+                        receives a direct file request. Using this option enables
+                        proxy.HttpWebServerPlugin.
   --pac-file-url-path PAC_FILE_URL_PATH
                         Default: /. Web server path to serve the PAC file.
   --proxy-pool PROXY_POOL
                         List of upstream proxies to use in the pool
   --filtered-client-ips FILTERED_CLIENT_IPS
-                        Default: 127.0.0.1,::1. Comma separated list of IPv4 and
-                        IPv6 addresses.
+                        Default: 127.0.0.1,::1. Comma separated list of IPv4 and IPv6 addresses.
   --filtered-url-regex-config FILTERED_URL_REGEX_CONFIG
-                        Default: No config. Comma separated list of IPv4 and IPv6
-                        addresses.
+                        Default: No config. Comma separated list of IPv4 and IPv6 addresses.
   --cloudflare-dns-mode CLOUDFLARE_DNS_MODE
-                        Default: security. Either "security" (for malware
-                        protection) or "family" (for malware and adult content
-                        protection)
+                        Default: security. Either "security" (for malware protection) or
+                        "family" (for malware and adult content protection)
 
-Proxy.py not working? Report at:
-https://github.com/abhinavsingh/proxy.py/issues/new
+Proxy.py not working? Report at: https://github.com/abhinavsingh/proxy.py/issues/new
 ```
 
 # Changelog

--- a/proxy/common/flag.py
+++ b/proxy/common/flag.py
@@ -135,14 +135,23 @@ class FlagParser:
 
         # Generate auth_code required for basic authentication if enabled
         auth_code = None
+        basic_auth = opts.get('basic_auth', args.basic_auth)
+        # Destroy passed credentials via flags or options
+        args.basic_auth = None
+        if 'basic_auth' in opts:
+            del opts['basic_auth']
+
+        # Resolve auth module.
         auth_plugins = []
-        if args.basic_auth:
-            auth_code = base64.b64encode(bytes_(args.basic_auth))
-            # Destroy passed credentials in flags, we don't need them any more
-            # args.basic_auth = None
-            auth_plugins = Plugins.resolve_plugin_flag(
-                args.auth_plugin, opts.get('auth_plugin'),
-            )
+        auth_plugin = opts.get('auth_plugin', args.auth_plugin)
+        if basic_auth:
+            auth_code = base64.b64encode(bytes_(basic_auth))
+        if basic_auth or auth_plugin != PLUGIN_PROXY_AUTH:
+            # No basic auth provided
+            # Here auth_plugin is set to default plugin
+            # We want to avoid loading the auth plugin (w/o basic auth)
+            # unless user overrides the default auth plugin.
+            auth_plugins.append(auth_plugin)
 
         # Load default plugins along with user provided --plugins
         default_plugins = [

--- a/proxy/common/flag.py
+++ b/proxy/common/flag.py
@@ -162,7 +162,8 @@ class FlagParser:
             args.plugins, opts.get('plugins', None),
         )
         plugins = Plugins.load(
-            default_plugins + auth_plugins + requested_plugins)
+            default_plugins + auth_plugins + requested_plugins,
+        )
 
         # https://github.com/python/mypy/issues/5865
         #

--- a/proxy/common/plugins.py
+++ b/proxy/common/plugins.py
@@ -46,11 +46,11 @@ class Plugins:
 
     @staticmethod
     def discover(input_args: List[str]) -> None:
-        """Search for plugin and plugins flag in command line arguments,
-        then iterates over each value and discovers the plugin.
+        """Search for external plugin found in command line arguments,
+        then iterates over each value and discover/import the plugin.
         """
         for i, f in enumerate(input_args):
-            if f in ('--plugin', '--plugins'):
+            if f in ('--plugin', '--plugins', '--auth-plugin'):
                 v = input_args[i + 1]
                 parts = v.split(',')
                 for part in parts:

--- a/proxy/common/plugins.py
+++ b/proxy/common/plugins.py
@@ -15,7 +15,7 @@ import inspect
 import itertools
 import importlib
 
-from typing import Any, List, Dict, Optional, Union
+from typing import Any, List, Dict, Optional, Tuple, Union
 
 from .utils import bytes_, text_
 from .constants import DOT, DEFAULT_ABC_PLUGINS, COMMA
@@ -83,7 +83,7 @@ class Plugins:
         return p
 
     @staticmethod
-    def importer(plugin: Union[bytes, type]) -> Any:
+    def importer(plugin: Union[bytes, type]) -> Tuple[type, str]:
         """Import and returns the plugin."""
         if isinstance(plugin, type):
             return (plugin, '__main__')

--- a/proxy/core/connection/server.py
+++ b/proxy/core/connection/server.py
@@ -33,7 +33,11 @@ class TcpServerConnection(TcpConnection):
             raise TcpConnectionUninitializedException()
         return self._conn
 
-    def connect(self, addr: Optional[Tuple[str, int]] = None, source_address: Optional[Tuple[str, int]] = None) -> None:
+    def connect(
+            self,
+            addr: Optional[Tuple[str, int]] = None,
+            source_address: Optional[Tuple[str, int]] = None,
+    ) -> None:
         if self._conn is None:
             self._conn = new_socket_connection(
                 addr or self.addr, source_address=source_address,

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -120,8 +120,7 @@ flags.add_argument(
     type=str,
     default=PLUGIN_PROXY_AUTH,
     help='Default: ' + PLUGIN_PROXY_AUTH + '.  ' +
-    'Auth plugin to use when --basic-auth flag is used.  ' +
-    'Override this flag if you want to use a custom auth mechanism.',
+    'Auth plugin to use instead of default basic auth plugin.',
 )
 
 

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -121,7 +121,7 @@ flags.add_argument(
     default=PLUGIN_PROXY_AUTH,
     help='Default: ' + PLUGIN_PROXY_AUTH + '.  ' +
     'Auth plugin to use when --basic-auth flag is used.  ' +
-    'Override this flag if you want to use a custom auth mechanism.'
+    'Override this flag if you want to use a custom auth mechanism.',
 )
 
 

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -25,7 +25,7 @@ from ..exception import HttpProtocolException, ProxyConnectionFailed
 from ..parser import HttpParser, httpParserStates, httpParserTypes, httpStatusCodes, httpMethods
 
 from ...common.types import Readables, Writables
-from ...common.constants import DEFAULT_CA_CERT_DIR, DEFAULT_CA_CERT_FILE, DEFAULT_CA_FILE
+from ...common.constants import DEFAULT_CA_CERT_DIR, DEFAULT_CA_CERT_FILE, DEFAULT_CA_FILE, PLUGIN_PROXY_AUTH
 from ...common.constants import DEFAULT_CA_KEY_FILE, DEFAULT_CA_SIGNING_KEY_FILE
 from ...common.constants import COMMA, DEFAULT_SERVER_RECVBUF_SIZE, DEFAULT_CERT_FILE
 from ...common.constants import PROXY_AGENT_HEADER_VALUE, DEFAULT_DISABLE_HEADERS
@@ -43,10 +43,28 @@ logger = logging.getLogger(__name__)
 
 
 flags.add_argument(
+    '--server-recvbuf-size',
+    type=int,
+    default=DEFAULT_SERVER_RECVBUF_SIZE,
+    help='Default: 1 MB. Maximum amount of data received from the '
+    'server in a single recv() operation. Bump this '
+    'value for faster downloads at the expense of '
+    'increased RAM.',
+)
+
+flags.add_argument(
     '--disable-http-proxy',
     action='store_true',
     default=DEFAULT_DISABLE_HTTP_PROXY,
     help='Default: False.  Whether to disable proxy.HttpProxyPlugin.',
+)
+
+flags.add_argument(
+    '--disable-headers',
+    type=str,
+    default=COMMA.join(DEFAULT_DISABLE_HEADERS),
+    help='Default: None.  Comma separated list of headers to remove before '
+    'dispatching client request to upstream server.',
 )
 
 flags.add_argument(
@@ -98,21 +116,12 @@ flags.add_argument(
 )
 
 flags.add_argument(
-    '--disable-headers',
+    '--auth-plugin',
     type=str,
-    default=COMMA.join(DEFAULT_DISABLE_HEADERS),
-    help='Default: None.  Comma separated list of headers to remove before '
-    'dispatching client request to upstream server.',
-)
-
-flags.add_argument(
-    '--server-recvbuf-size',
-    type=int,
-    default=DEFAULT_SERVER_RECVBUF_SIZE,
-    help='Default: 1 MB. Maximum amount of data received from the '
-    'server in a single recv() operation. Bump this '
-    'value for faster downloads at the expense of '
-    'increased RAM.',
+    default=PLUGIN_PROXY_AUTH,
+    help='Default: ' + PLUGIN_PROXY_AUTH + '.  ' +
+    'Auth plugin to use when --basic-auth flag is used.  ' +
+    'Override this flag if you want to use a custom auth mechanism.'
 )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ from unittest import mock
 from proxy.proxy import main, entry_point
 from proxy.common.utils import bytes_
 
-from proxy.common.constants import DEFAULT_ENABLE_DASHBOARD, DEFAULT_LOG_LEVEL, DEFAULT_LOG_FILE, DEFAULT_LOG_FORMAT, PLUGIN_PROXY_AUTH
+from proxy.common.constants import DEFAULT_ENABLE_DASHBOARD, DEFAULT_LOG_LEVEL, DEFAULT_LOG_FILE, DEFAULT_LOG_FORMAT
 from proxy.common.constants import DEFAULT_TIMEOUT, DEFAULT_DEVTOOLS_WS_PATH, DEFAULT_DISABLE_HTTP_PROXY
 from proxy.common.constants import DEFAULT_ENABLE_STATIC_SERVER, DEFAULT_ENABLE_EVENTS, DEFAULT_ENABLE_DEVTOOLS
 from proxy.common.constants import DEFAULT_ENABLE_WEB_SERVER, DEFAULT_THREADLESS, DEFAULT_CERT_FILE, DEFAULT_KEY_FILE
@@ -26,7 +26,7 @@ from proxy.common.constants import DEFAULT_PAC_FILE, DEFAULT_PLUGINS, DEFAULT_PI
 from proxy.common.constants import DEFAULT_NUM_WORKERS, DEFAULT_OPEN_FILE_LIMIT, DEFAULT_IPV6_HOSTNAME
 from proxy.common.constants import DEFAULT_SERVER_RECVBUF_SIZE, DEFAULT_CLIENT_RECVBUF_SIZE, DEFAULT_WORK_KLASS
 from proxy.common.constants import PLUGIN_INSPECT_TRAFFIC, PLUGIN_DASHBOARD, PLUGIN_DEVTOOLS_PROTOCOL, PLUGIN_WEB_SERVER
-from proxy.common.constants import PLUGIN_HTTP_PROXY, DEFAULT_NUM_ACCEPTORS
+from proxy.common.constants import PLUGIN_HTTP_PROXY, DEFAULT_NUM_ACCEPTORS, PLUGIN_PROXY_AUTH
 
 
 class TestMain(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ from unittest import mock
 from proxy.proxy import main, entry_point
 from proxy.common.utils import bytes_
 
-from proxy.common.constants import DEFAULT_ENABLE_DASHBOARD, DEFAULT_LOG_LEVEL, DEFAULT_LOG_FILE, DEFAULT_LOG_FORMAT
+from proxy.common.constants import DEFAULT_ENABLE_DASHBOARD, DEFAULT_LOG_LEVEL, DEFAULT_LOG_FILE, DEFAULT_LOG_FORMAT, PLUGIN_PROXY_AUTH
 from proxy.common.constants import DEFAULT_TIMEOUT, DEFAULT_DEVTOOLS_WS_PATH, DEFAULT_DISABLE_HTTP_PROXY
 from proxy.common.constants import DEFAULT_ENABLE_STATIC_SERVER, DEFAULT_ENABLE_EVENTS, DEFAULT_ENABLE_DEVTOOLS
 from proxy.common.constants import DEFAULT_ENABLE_WEB_SERVER, DEFAULT_THREADLESS, DEFAULT_CERT_FILE, DEFAULT_KEY_FILE
@@ -52,6 +52,7 @@ class TestMain(unittest.TestCase):
         mock_args.disable_http_proxy = DEFAULT_DISABLE_HTTP_PROXY
         mock_args.pac_file = DEFAULT_PAC_FILE
         mock_args.plugins = DEFAULT_PLUGINS
+        mock_args.auth_plugin = PLUGIN_PROXY_AUTH
         mock_args.server_recvbuf_size = DEFAULT_SERVER_RECVBUF_SIZE
         mock_args.client_recvbuf_size = DEFAULT_CLIENT_RECVBUF_SIZE
         mock_args.open_file_limit = DEFAULT_OPEN_FILE_LIMIT


### PR DESCRIPTION
1. `--auth-plugin` flag can now to used to customize auth plugin to use.  Usage of this flag will disable loading default basic auth plugin.  Instead, the plugin provided via `--auth-plugin` flag will be used.
2. If you also want `--basic-auth` to use within your custom auth plugin, you must also provide this flag.
