### PR TITLE
[IntegrationTest] Use `127.0.0.1` as target address and a random port

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -5,3 +5,9 @@ scm
 Threadless
 threadless
 youtube
+socio
+sexualized
+https
+www
+html
+faq

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -5,7 +5,11 @@ from typing import Generator
 
 import pytest
 
+from proxy.common.utils import get_available_port
 from proxy.common._compat import IS_WINDOWS  # noqa: WPS436
+
+
+PROXY_PY_PORT = get_available_port()
 
 
 # FIXME: Ignore is necessary for as long as pytest hasn't figured out
@@ -22,6 +26,7 @@ def _proxy_py_instance() -> Generator[None, None, None]:
     proxy_cmd = (
         'proxy',
         '--hostname', '127.0.0.1',
+        '--port', str(PROXY_PY_PORT),
         '--enable-web-server',
     )
     proxy_proc = Popen(proxy_cmd)
@@ -49,4 +54,4 @@ def test_curl() -> None:
     this_test_module = Path(__file__)
     shell_script_test = this_test_module.with_suffix('.sh')
 
-    check_output(str(shell_script_test))
+    check_output([str(shell_script_test), str(PROXY_PY_PORT)])

--- a/tests/integration/test_integration.sh
+++ b/tests/integration/test_integration.sh
@@ -9,9 +9,16 @@
 # to clean up any background process including
 # proxy.py
 
+PROXY_PY_PORT=$1
+if [[ -z "$PROXY_PY_PORT" ]]; then
+  echo "PROXY_PY_PORT required as argument."
+  exit 1
+fi
+
 # Wait for server to come up
+WAIT_FOR_PROXY="lsof -i TCP:$PROXY_PY_PORT | wc -l | tr -d ' '"
 while true; do
-    if [[ $(lsof -i TCP:8899 | wc -l | tr -d ' ') == 0 ]]; then
+    if [[ $WAIT_FOR_PORT == 0 ]]; then
         echo "Waiting for proxy..."
         sleep 1
     else
@@ -24,8 +31,8 @@ while true; do
     curl -v \
         --max-time 1 \
         --connect-timeout 1 \
-        -x localhost:8899 \
-        http://localhost:8899/ 2>/dev/null
+        -x 127.0.0.1:$PROXY_PY_PORT \
+        http://127.0.0.1:$PROXY_PY_PORT/ 2>/dev/null
     if [[ $? == 0 ]]; then
         break
     fi
@@ -41,7 +48,7 @@ done
 # detect if we have internet access.  If we do,
 # then use httpbin.org for integration testing.
 curl -v \
-    -x localhost:8899 \
+    -x 127.0.0.1:$PROXY_PY_PORT \
     http://httpbin.org/get
 if [[ $? != 0 ]]; then
     echo "http request failed"
@@ -49,7 +56,7 @@ if [[ $? != 0 ]]; then
 fi
 
 curl -v \
-    -x localhost:8899 \
+    -x 127.0.0.1:$PROXY_PY_PORT \
     https://httpbin.org/get
 if [[ $? != 0 ]]; then
     echo "https request failed"
@@ -57,8 +64,8 @@ if [[ $? != 0 ]]; then
 fi
 
 curl -v \
-    -x localhost:8899 \
-    http://localhost:8899/
+    -x 127.0.0.1:$PROXY_PY_PORT \
+    http://127.0.0.1:$PROXY_PY_PORT/
 if [[ $? != 0 ]]; then
     echo "http request to built in webserver failed"
     exit 1


### PR DESCRIPTION
1. Using `localhost` may not work reliably depending upon underlying IPv6 / IPv4 resolution differences.  Since we start proxy on `127.0.0.1`, let's use the same target address
2. Random port is necessary to avoid port conflicts during parallel test execution.

Also fixes doc spellchecks CI failing due to missing words