### PR TITLE
Handle `KeyboardInterrupt` in threadless

### DIFF
--- a/proxy/core/acceptor/threadless.py
+++ b/proxy/core/acceptor/threadless.py
@@ -313,6 +313,8 @@ class Threadless(ABC, Generic[T]):
                         break
                     tick = 0
                 tick += 1
+        except KeyboardInterrupt:
+            pass
         finally:
             if self.loop:
                 self.loop.stop()


### PR DESCRIPTION
Without which releases are currently throwing following exception on `CTRL+C`

```console
 File "/private/tmp/venv/lib/python3.9/site-packages/proxy/core/acceptor/threadless.py", line 307, in _run_forever
    if await self._run_once():
  File "/private/tmp/venv/lib/python3.9/site-packages/proxy/core/acceptor/threadless.py", line 280, in _run_once
    work_by_ids, new_work_available = await self._selected_events()
  File "/private/tmp/venv/lib/python3.9/site-packages/proxy/core/acceptor/threadless.py", line 196, in _selected_events
    selected = self.selector.select(
  File "/usr/local/Cellar/python@3.9/3.9.8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/selectors.py", line 562, in select
    kev_list = self._selector.control(None, max_ev, timeout)
KeyboardInterrupt
```