### PR TITLE
[ProxyPoolPlugin] Avoid remote proxy of private IP requests

### DIFF
--- a/proxy/http/plugin.py
+++ b/proxy/http/plugin.py
@@ -94,6 +94,7 @@ class HttpProtocolHandlerPlugin(ABC):
 
     @abstractmethod
     def on_client_data(self, raw: memoryview) -> Optional[memoryview]:
+        """Called only after original request has been completely received."""
         return raw  # pragma: no cover
 
     @abstractmethod

--- a/proxy/http/proxy/plugin.py
+++ b/proxy/http/proxy/plugin.py
@@ -121,6 +121,8 @@ class HttpProxyBasePlugin(ABC):
         Essentially, if you return None from within before_upstream_connection,
         be prepared to handle_client_data and not handle_client_request.
 
+        Only called after initial request from client has been received.
+
         Raise HttpRequestRejected to tear down the connection
         Return None to drop the connection
         """

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -903,7 +903,6 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
     def emit_request_complete(self) -> None:
         if not self.flags.enable_events:
             return
-
         assert self.request.port
         self.event_queue.publish(
             request_id=self.uid.hex,
@@ -924,7 +923,6 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
     def emit_response_events(self, chunk_size: int) -> None:
         if not self.flags.enable_events:
             return
-
         if self.response.state == httpParserStates.COMPLETE:
             self.emit_response_complete()
         elif self.response.state == httpParserStates.RCVING_BODY:
@@ -935,7 +933,6 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
     def emit_response_headers_complete(self) -> None:
         if not self.flags.enable_events:
             return
-
         self.event_queue.publish(
             request_id=self.uid.hex,
             event_name=eventNames.RESPONSE_HEADERS_COMPLETE,
@@ -948,7 +945,6 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
     def emit_response_chunk_received(self, chunk_size: int) -> None:
         if not self.flags.enable_events:
             return
-
         self.event_queue.publish(
             request_id=self.uid.hex,
             event_name=eventNames.RESPONSE_CHUNK_RECEIVED,
@@ -962,7 +958,6 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
     def emit_response_complete(self) -> None:
         if not self.flags.enable_events:
             return
-
         self.event_queue.publish(
             request_id=self.uid.hex,
             event_name=eventNames.RESPONSE_COMPLETE,

--- a/proxy/plugin/proxy_pool.py
+++ b/proxy/plugin/proxy_pool.py
@@ -10,10 +10,12 @@
 """
 import random
 import logging
+import ipaddress
 
 from typing import Dict, List, Optional, Any
 
 from ..common.flag import flags
+from ..common.utils import text_
 
 from ..http import Url, httpMethods
 from ..http.parser import HttpParser
@@ -78,15 +80,22 @@ class ProxyPoolPlugin(TcpUpstreamConnectionHandler, HttpProxyBasePlugin):
     ) -> Optional[HttpParser]:
         """Avoids establishing the default connection to upstream server
         by returning None.
+
+        TODO(abhinavsingh): Ideally connection to upstream proxy endpoints
+        must be bootstrapped within it's own re-usable and gc'd pool, to avoid establishing
+        a fresh upstream proxy connection for each client request.
+
+        See :class:`~proxy.core.connection.pool.ConnectionPool` which is a work
+        in progress for SSL cache handling.
         """
-        # TODO(abhinavsingh): Ideally connection to upstream proxy endpoints
-        # must be bootstrapped within it's own re-usable and gc'd pool, to avoid establishing
-        # a fresh upstream proxy connection for each client request.
-        #
-        # See :class:`~proxy.core.connection.pool.ConnectionPool` which is a work
-        # in progress for SSL cache handling.
-        #
-        # Implement your own logic here e.g. round-robin, least connection etc.
+        # We don't want to send private IP requests to remote proxies
+        try:
+            if ipaddress.ip_address(text_(request.host)).is_private:
+                return request
+        except ValueError:
+            pass
+        # Choose a random proxy from the pool
+        # TODO: Implement your own logic here e.g. round-robin, least connection etc.
         endpoint = random.choice(self.flags.proxy_pool)[0].split(':', 1)
         if endpoint[0] == 'localhost' and endpoint[1] == '8899':
             return request

--- a/proxy/plugin/proxy_pool.py
+++ b/proxy/plugin/proxy_pool.py
@@ -82,8 +82,8 @@ class ProxyPoolPlugin(TcpUpstreamConnectionHandler, HttpProxyBasePlugin):
         by returning None.
 
         TODO(abhinavsingh): Ideally connection to upstream proxy endpoints
-        must be bootstrapped within it's own re-usable and gc'd pool, to avoid establishing
-        a fresh upstream proxy connection for each client request.
+        must be bootstrapped within it's own re-usable and garbage collected pool,
+        to avoid establishing a new upstream proxy connection for each client request.
 
         See :class:`~proxy.core.connection.pool.ConnectionPool` which is a work
         in progress for SSL cache handling.

--- a/tests/http/test_http_proxy_tls_interception.py
+++ b/tests/http/test_http_proxy_tls_interception.py
@@ -145,9 +145,8 @@ class TestHttpProxyTlsInterception(Assertions):
         # Assert our mocked plugins invocations
         self.plugin.return_value.get_descriptors.assert_called()
         self.plugin.return_value.write_to_descriptors.assert_called_with([])
-        self.plugin.return_value.on_client_data.assert_called_with(
-            connect_request,
-        )
+        # on_client_data is only called after initial request has completed
+        self.plugin.return_value.on_client_data.assert_not_called()
         self.plugin.return_value.on_request_complete.assert_called()
         self.plugin.return_value.read_from_descriptors.assert_called_with([
             self._conn.fileno(),


### PR DESCRIPTION
Additionally, as `on_client_data` is only invoked after initial client request has been received, refactor to avoid unnecessary invocations.