### PR TITLE
[TLSInterception] Fix serial number generation

### DIFF
--- a/proxy/common/backports.py
+++ b/proxy/common/backports.py
@@ -55,6 +55,7 @@ class cached_property:
        backports
        getter
        Arndt
+       del
     """
 
     def __init__(self, ttl: float = 0):

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -87,7 +87,7 @@ flags.add_argument(
     '--ca-cert-dir',
     type=str,
     default=DEFAULT_CA_CERT_DIR,
-    help='Default: ~/.proxy.py. Directory to store dynamically generated certificates. '
+    help='Default: ~/.proxy/certificates. Directory to store dynamically generated certificates. '
     'Also see --ca-key-file, --ca-cert-file and --ca-signing-key-file',
 )
 
@@ -730,7 +730,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
         ca_key_path = self.flags.ca_key_file
         ca_key_password = ''
         ca_crt_path = self.flags.ca_cert_file
-        serial = self.uid
+        serial = '%d%d' % (time.time(), os.getpid())
 
         # Sign generated CSR
         if not os.path.isfile(cert_file_path):


### PR DESCRIPTION
1. `self.uid` is now no longer a compliant `serial_id` for certificate signing.
2. This resulted in broken TLS Interception experience.