### PR TITLE
Avoid registering invalid FD with selectors

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -485,12 +485,13 @@ jobs:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: >-
           ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          hashFiles('tox.ini', 'requirements.txt', 'requirements-testing.txt')
+            steps.calc-cache-key-py.outputs.py-hash-key
+          }}-${{
+            hashFiles('tox.ini', 'requirements**.txt')
           }}
         restore-keys: |
           ${{ runner.os }}-pip-${{
-              steps.calc-cache-key-py.outputs.py-hash-key
+            steps.calc-cache-key-py.outputs.py-hash-key
           }}-
           ${{ runner.os }}-pip-
     - name: Install tox

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -746,8 +746,11 @@ jobs:
     - name: Tag latest on GHCR
       if: >-
         github.event_name == 'push' &&
-        github.ref == format(
-          'refs/heads/{0}', github.event.repository.default_branch
+        (
+          github.ref == format(
+            'refs/heads/{0}', github.event.repository.default_branch
+          ) ||
+          github.ref == 'refs/heads/master'
         )
       run: >-
         REGISTRY_URL="ghcr.io/abhinavsingh/proxy.py";

--- a/proxy/core/acceptor/threadless.py
+++ b/proxy/core/acceptor/threadless.py
@@ -180,7 +180,7 @@ class Threadless(ABC, Generic[T]):
                 # else:
                 #     logger.info(
                 #         'fd#{0} by work#{1} not modified'.format(fileno, work_id))
-            else:
+            elif fileno != -1:
                 # Can throw ValueError: Invalid file descriptor: -1
                 #
                 # A guard within Work classes may not help here due to


### PR DESCRIPTION
This can happen during TLS Interception when upstream server rejects the offered certificates by `proxy.py` instance.

Additionally:
1. Now include all `requirements**.txt` file within workflow cache keys
2. Also add `latest` tag from `master` branch