### PR TITLE
Change `--local-executor` flag semantics

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -754,7 +754,8 @@ jobs:
         $CONTAINER_TAG
         --hostname 0.0.0.0
         --enable-web-server
-        --local-executor && ./tests/integration/test_integration.sh 8899
+        &&
+        ./tests/integration/test_integration.sh 8899
     - name: Push to GHCR
       run: >-
         REGISTRY_URL="ghcr.io/abhinavsingh/proxy.py";

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,4 @@ EXPOSE 8899/tcp
 ENTRYPOINT [ "proxy" ]
 CMD [ \
   "--hostname=0.0.0.0" \
-  "--local-executor" \
   ]

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,6 @@ lib-profile:
 			--num-workers 1 \
 			--enable-web-server \
 			--plugin proxy.plugin.WebServerPlugin \
-			--local-executor \
 			--backlog 65536 \
 			--open-file-limit 65536 \
 			--log-file /dev/null
@@ -160,7 +159,6 @@ lib-speedscope:
 			--num-workers 1 \
 			--enable-web-server \
 			--plugin proxy.plugin.WebServerPlugin \
-			--local-executor \
 			--backlog 65536 \
 			--open-file-limit 65536 \
 			--log-file /dev/null

--- a/README.md
+++ b/README.md
@@ -2204,8 +2204,9 @@ To run standalone benchmark for `proxy.py`, use the following command from repo 
 ```console
 ❯ proxy -h
 usage: -m [-h] [--enable-events] [--enable-conn-pool] [--threadless]
-          [--threaded] [--num-workers NUM_WORKERS] [--local-executor]
-          [--backlog BACKLOG] [--hostname HOSTNAME] [--port PORT]
+          [--threaded] [--num-workers NUM_WORKERS]
+          [--local-executor LOCAL_EXECUTOR] [--backlog BACKLOG]
+          [--hostname HOSTNAME] [--port PORT]
           [--unix-socket-path UNIX_SOCKET_PATH]
           [--num-acceptors NUM_ACCEPTORS] [--version] [--log-level LOG_LEVEL]
           [--log-file LOG_FILE] [--log-format LOG_FORMAT]
@@ -2248,13 +2249,14 @@ options:
                         handle each client connection.
   --num-workers NUM_WORKERS
                         Defaults to number of CPU cores.
-  --local-executor      Default: True. Disabled by default. When enabled
-                        acceptors will make use of local (same process)
-                        executor instead of distributing load across remote
-                        (other process) executors. Enable this option to
-                        achieve CPU affinity between acceptors and executors,
-                        instead of using underlying OS kernel scheduling
-                        algorithm.
+  --local-executor LOCAL_EXECUTOR
+                        Default: 1. Enabled by default. Use 0 to disable. When
+                        enabled acceptors will make use of local (same
+                        process) executor instead of distributing load across
+                        remote (other process) executors. Enable this option
+                        to achieve CPU affinity between acceptors and
+                        executors, instead of using underlying OS kernel
+                        scheduling algorithm.
   --backlog BACKLOG     Default: 100. Maximum number of pending connections to
                         proxy server
   --hostname HOSTNAME   Default: 127.0.0.1. Server IP address.

--- a/benchmark/_proxy.py
+++ b/benchmark/_proxy.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
             enable_web_server=True,
             disable_proxy_server=False,
             num_acceptors=10,
-            local_executor=True,
+            local_executor=1,
             log_file='/dev/null',
     ) as _:
         while True:

--- a/proxy/common/flag.py
+++ b/proxy/common/flag.py
@@ -340,7 +340,7 @@ class FlagParser:
         )
         args.timeout = cast(int, opts.get('timeout', args.timeout))
         args.local_executor = cast(
-            bool,
+            int,
             opts.get(
                 'local_executor',
                 args.local_executor,

--- a/proxy/core/acceptor/acceptor.py
+++ b/proxy/core/acceptor/acceptor.py
@@ -40,10 +40,10 @@ logger = logging.getLogger(__name__)
 
 flags.add_argument(
     '--local-executor',
-    action='store_true',
-    default=DEFAULT_LOCAL_EXECUTOR,
-    help='Default: ' + ('True' if DEFAULT_LOCAL_EXECUTOR else 'False') + '.  ' +
-    'Disabled by default.  When enabled acceptors will make use of ' +
+    type=int,
+    default=int(DEFAULT_LOCAL_EXECUTOR),
+    help='Default: ' + ('1' if DEFAULT_LOCAL_EXECUTOR else '0') + '.  ' +
+    'Enabled by default.  When enabled acceptors will make use of ' +
     'local (same process) executor instead of distributing load across ' +
     'remote (other process) executors.  Enable this option to achieve CPU affinity between ' +
     'acceptors and executors, instead of using underlying OS kernel scheduling algorithm.',

--- a/proxy/core/acceptor/acceptor.py
+++ b/proxy/core/acceptor/acceptor.py
@@ -149,7 +149,7 @@ class Acceptor(multiprocessing.Process):
                 if locked:
                     self.lock.release()
             for work in works:
-                if self.flags.local_executor:
+                if self.flags.local_executor == int(DEFAULT_LOCAL_EXECUTOR):
                     assert self._local_work_queue
                     self._local_work_queue.put(work)
                 else:
@@ -172,7 +172,7 @@ class Acceptor(multiprocessing.Process):
             type=socket.SOCK_STREAM,
         )
         try:
-            if self.flags.local_executor:
+            if self.flags.local_executor == int(DEFAULT_LOCAL_EXECUTOR):
                 self._start_local()
             self.selector.register(self.sock, selectors.EVENT_READ)
             while not self.running.is_set():
@@ -181,7 +181,7 @@ class Acceptor(multiprocessing.Process):
             pass
         finally:
             self.selector.unregister(self.sock)
-            if self.flags.local_executor:
+            if self.flags.local_executor == int(DEFAULT_LOCAL_EXECUTOR):
                 self._stop_local()
             self.sock.close()
             logger.debug('Acceptor#%d shutdown', self.idd)

--- a/proxy/core/acceptor/acceptor.py
+++ b/proxy/core/acceptor/acceptor.py
@@ -43,8 +43,8 @@ flags.add_argument(
     type=int,
     default=int(DEFAULT_LOCAL_EXECUTOR),
     help='Default: ' + ('1' if DEFAULT_LOCAL_EXECUTOR else '0') + '.  ' +
-    'Enabled by default.  When enabled acceptors will make use of ' +
-    'local (same process) executor instead of distributing load across ' +
+    'Enabled by default.  Use 0 to disable.  When enabled acceptors ' +
+    'will make use of local (same process) executor instead of distributing load across ' +
     'remote (other process) executors.  Enable this option to achieve CPU affinity between ' +
     'acceptors and executors, instead of using underlying OS kernel scheduling algorithm.',
 )

--- a/proxy/core/acceptor/pool.py
+++ b/proxy/core/acceptor/pool.py
@@ -98,7 +98,17 @@ class AcceptorPool:
     def setup(self) -> None:
         """Setup acceptors."""
         self._start()
-        logger.info('Started %d acceptors' % self.flags.num_acceptors)
+        execution_mode = (
+            "threadless (local)"
+            if self.flags.local_executor
+            else "threadless (remote)"
+        ) if self.flags.threadless else "threaded"
+        logger.info(
+            'Started %d acceptors in %s mode' % (
+                self.flags.num_acceptors,
+                execution_mode,
+            ),
+        )
         # Send file descriptor to all acceptor processes.
         fd = self.listener.fileno()
         for index in range(self.flags.num_acceptors):

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -222,7 +222,8 @@ class Proxy:
 
     @property
     def remote_executors_enabled(self) -> bool:
-        return self.flags.threadless and self.flags.local_executor != int(DEFAULT_LOCAL_EXECUTOR)
+        return self.flags.threadless \
+            and not (self.flags.local_executor == int(DEFAULT_LOCAL_EXECUTOR))
 
 
 def main(**opts: Any) -> None:

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -206,7 +206,8 @@ class Proxy:
         self._delete_pid_file()
 
     def _write_pid_file(self) -> None:
-        if self.flags.pid_file is not None:
+        if self.flags.pid_file is not None \
+                and type(self.flags.pid_file) == str:
             if Path(self.flags.pid_file).exists():
                 raise ValueError(
                     'pid file {0} already exists'.format(
@@ -217,7 +218,9 @@ class Proxy:
                 pid_file.write(bytes_(os.getpid()))
 
     def _delete_pid_file(self) -> None:
-        if self.flags.pid_file and os.path.exists(self.flags.pid_file):
+        if self.flags.pid_file \
+            and type(self.flags.pid_file) == str \
+                and os.path.exists(self.flags.pid_file):
             os.remove(self.flags.pid_file)
 
     @property

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -13,7 +13,6 @@ import sys
 import time
 import logging
 
-from pathlib import Path
 from typing import List, Optional, Any
 
 from .core.acceptor import AcceptorPool, ThreadlessPool, Listener
@@ -206,20 +205,12 @@ class Proxy:
         self._delete_pid_file()
 
     def _write_pid_file(self) -> None:
-        if self.flags.pid_file is not None \
-                and type(self.flags.pid_file) == str:
-            if Path(self.flags.pid_file).exists():
-                raise ValueError(
-                    'pid file {0} already exists'.format(
-                        self.flags.pid_file,
-                    ),
-                )
+        if self.flags.pid_file:
             with open(self.flags.pid_file, 'wb') as pid_file:
                 pid_file.write(bytes_(os.getpid()))
 
     def _delete_pid_file(self) -> None:
         if self.flags.pid_file \
-            and type(self.flags.pid_file) == str \
                 and os.path.exists(self.flags.pid_file):
             os.remove(self.flags.pid_file)
 

--- a/tests/core/test_acceptor.py
+++ b/tests/core/test_acceptor.py
@@ -26,7 +26,7 @@ class TestAcceptor(unittest.TestCase):
         self.flags = FlagParser.initialize(
             threaded=True,
             work_klass=mock.MagicMock(),
-            local_executor=False,
+            local_executor=0,
         )
         self.acceptor = Acceptor(
             idd=self.acceptor_id,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -59,7 +59,7 @@ def proxy_py_subprocess(request: Any) -> Generator[int, None, None]:
     'proxy_py_subprocess',
     (
         ('--threadless'),
-        ('--threadless --local-executor'),
+        ('--threadless --local-executor 0'),
         ('--threaded'),
     ),
     indirect=True,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -68,7 +68,7 @@ class TestMain(unittest.TestCase):
         mock_args.enable_events = DEFAULT_ENABLE_EVENTS
         mock_args.enable_dashboard = DEFAULT_ENABLE_DASHBOARD
         mock_args.work_klass = DEFAULT_WORK_KLASS
-        mock_args.local_executor = DEFAULT_LOCAL_EXECUTOR
+        mock_args.local_executor = int(DEFAULT_LOCAL_EXECUTOR)
 
     @mock.patch('os.remove')
     @mock.patch('os.path.exists')
@@ -93,7 +93,7 @@ class TestMain(unittest.TestCase):
     ) -> None:
         pid_file = os.path.join(tempfile.gettempdir(), 'pid')
         mock_sleep.side_effect = KeyboardInterrupt()
-        mock_initialize.return_value.local_executor = False
+        mock_initialize.return_value.local_executor = 0
         mock_initialize.return_value.enable_events = False
         mock_initialize.return_value.pid_file = pid_file
         entry_point()
@@ -141,7 +141,7 @@ class TestMain(unittest.TestCase):
             mock_sleep: mock.Mock,
     ) -> None:
         mock_sleep.side_effect = KeyboardInterrupt()
-        mock_initialize.return_value.local_executor = False
+        mock_initialize.return_value.local_executor = 0
         mock_initialize.return_value.enable_events = False
         main()
         mock_event_manager.assert_not_called()
@@ -181,7 +181,7 @@ class TestMain(unittest.TestCase):
             mock_sleep: mock.Mock,
     ) -> None:
         mock_sleep.side_effect = KeyboardInterrupt()
-        mock_initialize.return_value.local_executor = False
+        mock_initialize.return_value.local_executor = 0
         mock_initialize.return_value.enable_events = True
         main()
         mock_event_manager.assert_called_once()
@@ -228,8 +228,8 @@ class TestMain(unittest.TestCase):
         mock_args = mock_parse_args.return_value
         self.mock_default_args(mock_args)
         mock_args.enable_dashboard = True
-        mock_args.local_executor = False
-        main(enable_dashboard=True, local_executor=False)
+        mock_args.local_executor = 0
+        main(enable_dashboard=True, local_executor=0)
         mock_load_plugins.assert_called()
         self.assertEqual(
             mock_load_plugins.call_args_list[0][0][0], [
@@ -274,8 +274,8 @@ class TestMain(unittest.TestCase):
         mock_args = mock_parse_args.return_value
         self.mock_default_args(mock_args)
         mock_args.enable_devtools = True
-        mock_args.local_executor = False
-        main(enable_devtools=True, local_executor=False)
+        mock_args.local_executor = 0
+        main(enable_devtools=True, local_executor=0)
         mock_load_plugins.assert_called()
         self.assertEqual(
             mock_load_plugins.call_args_list[0][0][0], [


### PR DESCRIPTION
Now an integer, previously a boolean.  Now `--local-executor` is enabled by default i.e. it's value is 1.  Use `--local-executor 0` to use remote threadless execution mode.