### PR TITLE
[Middleware] Capability in the core to allow custom client connection classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ sign-https-certificates:
 	python -m proxy.common.pki sign_csr \
 		--csr-path $(HTTPS_CSR_FILE_PATH) \
 		--crt-path $(HTTPS_SIGNED_CERT_FILE_PATH) \
-		--hostname example.com \
+		--hostname localhost \
 		--private-key-path $(CA_KEY_FILE_PATH) \
 		--public-key-path $(CA_CERT_FILE_PATH)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -316,4 +316,5 @@ nitpick_ignore = [
     (_py_class_role, 'EventQueue'),
     (_py_obj_role, 'proxy.core.work.threadless.T'),
     (_py_obj_role, 'proxy.core.work.work.T'),
+    (_py_obj_role, 'proxy.core.base.tcp_server.T'),
 ]

--- a/examples/ssl_echo_server.py
+++ b/examples/ssl_echo_server.py
@@ -17,7 +17,7 @@ from proxy.common.utils import wrap_socket
 from proxy.core.connection import TcpClientConnection
 
 
-class EchoSSLServerHandler(BaseTcpServerHandler):
+class EchoSSLServerHandler(BaseTcpServerHandler[TcpClientConnection]):
     """Wraps client socket during initialization."""
 
     def initialize(self) -> None:

--- a/examples/tcp_echo_server.py
+++ b/examples/tcp_echo_server.py
@@ -13,9 +13,10 @@ from typing import Optional
 
 from proxy import Proxy
 from proxy.core.base import BaseTcpServerHandler
+from proxy.core.connection import TcpClientConnection
 
 
-class EchoServerHandler(BaseTcpServerHandler):
+class EchoServerHandler(BaseTcpServerHandler[TcpClientConnection]):
     """Sets client socket to non-blocking during initialization."""
 
     def initialize(self) -> None:

--- a/proxy/common/pki.py
+++ b/proxy/common/pki.py
@@ -268,8 +268,8 @@ if __name__ == '__main__':
     parser.add_argument(
         '--subject',
         type=str,
-        default='/CN=example.com',
-        help='Subject to use for public key generation. Default: /CN=example.com',
+        default='/CN=localhost',
+        help='Subject to use for public key generation. Default: /CN=localhost',
     )
     parser.add_argument(
         '--csr-path',

--- a/proxy/core/base/tcp_server.py
+++ b/proxy/core/base/tcp_server.py
@@ -12,17 +12,69 @@
 
        tcp
 """
+import ssl
+import socket
 import logging
 import selectors
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, Optional, Union
+
+from ...common.flag import flags
+from ...common.utils import wrap_socket
+from ...common.types import Readables, SelectableEvents, Writables
+from ...common.constants import DEFAULT_CERT_FILE, DEFAULT_CLIENT_RECVBUF_SIZE
+from ...common.constants import DEFAULT_KEY_FILE, DEFAULT_SERVER_RECVBUF_SIZE, DEFAULT_TIMEOUT
 
 from ...core.work import Work
 from ...core.connection import TcpClientConnection
-from ...common.types import Readables, SelectableEvents, Writables
 
 logger = logging.getLogger(__name__)
+
+
+flags.add_argument(
+    '--key-file',
+    type=str,
+    default=DEFAULT_KEY_FILE,
+    help='Default: None. Server key file to enable end-to-end TLS encryption with clients. '
+    'If used, must also pass --cert-file.',
+)
+
+flags.add_argument(
+    '--cert-file',
+    type=str,
+    default=DEFAULT_CERT_FILE,
+    help='Default: None. Server certificate to enable end-to-end TLS encryption with clients. '
+    'If used, must also pass --key-file.',
+)
+
+flags.add_argument(
+    '--client-recvbuf-size',
+    type=int,
+    default=DEFAULT_CLIENT_RECVBUF_SIZE,
+    help='Default: ' + str(int(DEFAULT_CLIENT_RECVBUF_SIZE / 1024)) +
+    ' KB. Maximum amount of data received from the '
+    'client in a single recv() operation.',
+)
+
+flags.add_argument(
+    '--server-recvbuf-size',
+    type=int,
+    default=DEFAULT_SERVER_RECVBUF_SIZE,
+    help='Default: ' + str(int(DEFAULT_SERVER_RECVBUF_SIZE / 1024)) +
+    ' KB. Maximum amount of data received from the '
+    'server in a single recv() operation.',
+)
+
+flags.add_argument(
+    '--timeout',
+    type=int,
+    default=DEFAULT_TIMEOUT,
+    help='Default: ' + str(DEFAULT_TIMEOUT) +
+    '.  Number of seconds after which '
+    'an inactive connection must be dropped.  Inactivity is defined by no '
+    'data sent or received by the client.',
+)
 
 
 class BaseTcpServerHandler(Work[TcpClientConnection]):
@@ -55,6 +107,17 @@ class BaseTcpServerHandler(Work[TcpClientConnection]):
             self.work.connection.fileno(),
             self.work.address,
         )
+
+    def initialize(self) -> None:
+        """Optionally upgrades connection to HTTPS,
+        sets ``conn`` in non-blocking mode and initializes
+        HTTP protocol plugins."""
+        conn = self._optionally_wrap_socket(self.work.connection)
+        conn.setblocking(False)
+        # Update client connection reference if connection was wrapped
+        if self._encryption_enabled():
+            self.work = TcpClientConnection(conn=conn, addr=self.work.addr)
+        logger.debug('Handling connection %s' % self.work.address)
 
     @abstractmethod
     def handle_data(self, data: memoryview) -> Optional[bool]:
@@ -139,3 +202,20 @@ class BaseTcpServerHandler(Work[TcpClientConnection]):
                     else:
                         teardown = True
         return teardown
+
+    def _encryption_enabled(self) -> bool:
+        return self.flags.keyfile is not None and \
+            self.flags.certfile is not None
+
+    def _optionally_wrap_socket(
+            self, conn: socket.socket,
+    ) -> Union[ssl.SSLSocket, socket.socket]:
+        """Attempts to wrap accepted client connection using provided certificates.
+
+        Shutdown and closes client connection upon error.
+        """
+        if self._encryption_enabled():
+            assert self.flags.keyfile and self.flags.certfile
+            # TODO(abhinavsingh): Insecure TLS versions must not be accepted by default
+            conn = wrap_socket(conn, self.flags.keyfile, self.flags.certfile)
+        return conn

--- a/proxy/core/base/tcp_tunnel.py
+++ b/proxy/core/base/tcp_tunnel.py
@@ -18,13 +18,13 @@ from ...http.parser import HttpParser, httpParserTypes
 from ...common.types import Readables, SelectableEvents, Writables
 from ...common.utils import text_
 
-from ..connection import TcpServerConnection
+from ..connection import TcpServerConnection, TcpClientConnection
 from .tcp_server import BaseTcpServerHandler
 
 logger = logging.getLogger(__name__)
 
 
-class BaseTcpTunnelHandler(BaseTcpServerHandler):
+class BaseTcpTunnelHandler(BaseTcpServerHandler[TcpClientConnection]):
     """BaseTcpTunnelHandler build on-top of BaseTcpServerHandler work class.
 
     On-top of BaseTcpServerHandler implementation,

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -37,9 +37,9 @@ from ..responses import PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT
 from ...common.types import Readables, Writables, Descriptors
 from ...common.constants import DEFAULT_CA_CERT_DIR, DEFAULT_CA_CERT_FILE, DEFAULT_CA_FILE
 from ...common.constants import DEFAULT_CA_KEY_FILE, DEFAULT_CA_SIGNING_KEY_FILE
-from ...common.constants import COMMA, DEFAULT_SERVER_RECVBUF_SIZE, DEFAULT_CERT_FILE
+from ...common.constants import COMMA, DEFAULT_HTTPS_PROXY_ACCESS_LOG_FORMAT
 from ...common.constants import PROXY_AGENT_HEADER_VALUE, DEFAULT_DISABLE_HEADERS
-from ...common.constants import DEFAULT_HTTP_PROXY_ACCESS_LOG_FORMAT, DEFAULT_HTTPS_PROXY_ACCESS_LOG_FORMAT
+from ...common.constants import DEFAULT_HTTP_PROXY_ACCESS_LOG_FORMAT
 from ...common.constants import DEFAULT_DISABLE_HTTP_PROXY, PLUGIN_PROXY_AUTH
 from ...common.utils import text_
 from ...common.pki import gen_public_key, gen_csr, sign_csr
@@ -51,15 +51,6 @@ from ...common.flag import flags
 
 logger = logging.getLogger(__name__)
 
-
-flags.add_argument(
-    '--server-recvbuf-size',
-    type=int,
-    default=DEFAULT_SERVER_RECVBUF_SIZE,
-    help='Default: ' + str(int(DEFAULT_SERVER_RECVBUF_SIZE / 1024)) +
-    ' KB. Maximum amount of data received from the '
-    'server in a single recv() operation.',
-)
 
 flags.add_argument(
     '--disable-http-proxy',
@@ -114,14 +105,6 @@ flags.add_argument(
     default=DEFAULT_CA_SIGNING_KEY_FILE,
     help='Default: None. CA signing key to use for dynamic generation of '
     'HTTPS certificates.  If used, must also pass --ca-key-file and --ca-cert-file',
-)
-
-flags.add_argument(
-    '--cert-file',
-    type=str,
-    default=DEFAULT_CERT_FILE,
-    help='Default: None. Server certificate to enable end-to-end TLS encryption with clients. '
-    'If used, must also pass --key-file.',
 )
 
 flags.add_argument(

--- a/proxy/plugin/web_server_route.py
+++ b/proxy/plugin/web_server_route.py
@@ -18,7 +18,7 @@ from ..http.server import HttpWebServerBasePlugin, httpProtocolTypes
 logger = logging.getLogger(__name__)
 
 HTTP_RESPONSE = okResponse(content=b'HTTP route response')
-HTTPS_RESPONSE = okResponse(content=b'HTTP route response')
+HTTPS_RESPONSE = okResponse(content=b'HTTPS route response')
 
 
 class WebServerPlugin(HttpWebServerBasePlugin):

--- a/tests/common/test_pki.py
+++ b/tests/common/test_pki.py
@@ -123,7 +123,7 @@ class TestPki(unittest.TestCase):
     def _gen_public_private_key(self) -> Tuple[str, str, str]:
         key_path, nopass_key_path = self._gen_private_key()
         crt_path = os.path.join(self._tempdir, 'test_gen_public.crt')
-        pki.gen_public_key(crt_path, key_path, 'password', '/CN=example.com')
+        pki.gen_public_key(crt_path, key_path, 'password', '/CN=localhost')
         return (key_path, nopass_key_path, crt_path)
 
     def _gen_private_key(self) -> Tuple[str, str]:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -134,6 +134,7 @@ def proxy_py_subprocess(request: Any) -> Generator[int, None, None]:
         '--port', '0',
         '--port-file', str(port_file),
         '--enable-web-server',
+        '--plugin', 'proxy.plugin.WebServerPlugin',
         '--num-acceptors', '3',
         '--num-workers', '3',
         '--ca-cert-dir', str(ca_cert_dir),

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -187,7 +187,7 @@ def test_https_integration(proxy_py_subprocess: int) -> None:
     this_test_module = Path(__file__)
     shell_script_test = this_test_module.with_suffix('.sh')
     # "1" means use-https scheme for requests to instance
-    check_output([str(shell_script_test), str(proxy_py_subprocess), "1"])
+    check_output([str(shell_script_test), str(proxy_py_subprocess), '1'])
 
 
 @pytest.mark.smoke  # type: ignore[misc]

--- a/tests/integration/test_integration.sh
+++ b/tests/integration/test_integration.sh
@@ -28,9 +28,8 @@ CURL_EXTRA_FLAGS=""
 USE_HTTPS=$2
 if [[ ! -z "$USE_HTTPS" ]]; then
     PROXY_URL="https://localhost:$PROXY_PY_PORT"
-    CURL_EXTRA_FLAGS="-k --proxy-insecure"
+    CURL_EXTRA_FLAGS=" -k --proxy-insecure "
 fi
-
 
 # Wait for server to come up
 WAIT_FOR_PROXY="lsof -i TCP:$PROXY_PY_PORT | wc -l | tr -d ' '"
@@ -44,13 +43,9 @@ while true; do
 done
 
 # Wait for http proxy and web server to start
+CMD="curl -v --max-time 1 --connect-timeout 1 $CURL_EXTRA_FLAGS -x $PROXY_URL $PROXY_URL"
 while true; do
-    curl -v \
-        --max-time 1 \
-        --connect-timeout 1 \
-        -x "$PROXY_URL" \
-        "$CURL_EXTRA_FLAGS" \
-        "$PROXY_URL" 2>/dev/null
+    RESPONSE=$($CMD 2> /dev/null)
     if [[ $? == 0 ]]; then
         break
     fi
@@ -88,21 +83,21 @@ Disallow: /deny
 EOM
 
 echo "[Test HTTP Request via Proxy]"
-CMD="curl -v -x $PROXY_URL $CURL_EXTRA_FLAGS http://httpbin.org/robots.txt"
+CMD="curl -v $CURL_EXTRA_FLAGS -x $PROXY_URL http://httpbin.org/robots.txt"
 RESPONSE=$($CMD 2> /dev/null)
 verify_response "$RESPONSE" "$ROBOTS_RESPONSE"
 VERIFIED1=$?
 
 echo "[Test HTTPS Request via Proxy]"
-CMD="curl -v -x $PROXY_URL $CURL_EXTRA_FLAGS https://httpbin.org/robots.txt"
+CMD="curl -v $CURL_EXTRA_FLAGS -x $PROXY_URL https://httpbin.org/robots.txt"
 RESPONSE=$($CMD 2> /dev/null)
 verify_response "$RESPONSE" "$ROBOTS_RESPONSE"
 VERIFIED2=$?
 
 echo "[Test Internal Web Server via Proxy]"
 curl -v \
-    -x $PROXY_URL \
     $CURL_EXTRA_FLAGS \
+    -x $PROXY_URL \
     "$PROXY_URL"
 VERIFIED3=$?
 
@@ -116,9 +111,9 @@ echo "[Test Download File Hash Verifies 1]"
 touch downloaded.hash
 echo "3d1921aab49d3464a712c1c1397b6babf8b461a9873268480aa8064da99441bc  -" > downloaded.hash
 curl -vL \
+    $CURL_EXTRA_FLAGS \
     -o downloaded.whl \
     -x $PROXY_URL \
-    $CURL_EXTRA_FLAGS \
     https://files.pythonhosted.org/packages/88/78/e642316313b1cd6396e4b85471a316e003eff968f29773e95ea191ea1d08/proxy.py-2.4.0rc4-py3-none-any.whl#sha256=3d1921aab49d3464a712c1c1397b6babf8b461a9873268480aa8064da99441bc
 cat downloaded.whl | $SHASUM -c downloaded.hash
 VERIFIED4=$?
@@ -128,9 +123,9 @@ echo "[Test Download File Hash Verifies 2]"
 touch downloaded.hash
 echo "077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8  -" > downloaded.hash
 curl -vL \
+    $CURL_EXTRA_FLAGS \
     -o downloaded.whl \
     -x $PROXY_URL \
-    $CURL_EXTRA_FLAGS \
     https://files.pythonhosted.org/packages/20/9a/e5d9ec41927401e41aea8af6d16e78b5e612bca4699d417f646a9610a076/Jinja2-3.0.3-py3-none-any.whl#sha256=077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8
 cat downloaded.whl | $SHASUM -c downloaded.hash
 VERIFIED5=$?


### PR DESCRIPTION
## This PR
- Adds capability to the core so that a custom `HttpClientConnection` object can be shared with plugins instead of the current default `TcpClientConnection`.
- Add integration tests for `HTTPS` web and proxy server

## Agenda: All plugins must use client.response not client.queue

Using `client.queue` works but imposes challenges for outgoing response handling/customization/inspection.  Instead all plugins must now call `client.response`.  Internally, it works the same as `client.queue`.  Just that now, plugins must queue a `HttpParser`, `WebsocketFrame` etc objects instead of `memoryview` or raw `bytes`.

By doing so it becomes possible for the core to provide a response based callback eco-system e.g. proxy plugins can modify/update responses queued by other plugins (currently only a single plugin can technically send response).  Also, we'll be able to add `middleware` support for proxy and web server plugins.

Note that `client.queue` itself will continue to work.  Just that such plugins will not be able to take advantage of core capabilities that will depend upon plugins use of `client.response`.   At some point in far future, `client.queue` method will be made private.
