### PR TITLE
[Middleware] `HttpClientConnection` preparation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -308,6 +308,7 @@ nitpick_ignore = [
     (_py_class_role, 'unittest.result.TestResult'),
     (_py_class_role, 'UUID'),
     (_py_class_role, 'UpstreamConnectionPool'),
+    (_py_class_role, 'HttpClientConnection'),
     (_py_class_role, 'Url'),
     (_py_class_role, 'WebsocketFrame'),
     (_py_class_role, 'Work'),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -315,6 +315,7 @@ nitpick_ignore = [
     (_py_class_role, 'proxy.core.acceptor.work.Work'),
     (_py_class_role, 'connection.Connection'),
     (_py_class_role, 'EventQueue'),
+    (_py_class_role, 'T'),
     (_py_obj_role, 'proxy.core.work.threadless.T'),
     (_py_obj_role, 'proxy.core.work.work.T'),
     (_py_obj_role, 'proxy.core.base.tcp_server.T'),

--- a/examples/ssl_echo_server.py
+++ b/examples/ssl_echo_server.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import time
-from typing import Optional
+from typing import Any, Optional
 
 from proxy import Proxy
 from proxy.core.base import BaseTcpServerHandler
@@ -19,6 +19,10 @@ from proxy.core.connection import TcpClientConnection
 
 class EchoSSLServerHandler(BaseTcpServerHandler[TcpClientConnection]):
     """Wraps client socket during initialization."""
+
+    @staticmethod
+    def create(**kwargs: Any) -> TcpClientConnection:
+        return TcpClientConnection(**kwargs)
 
     def initialize(self) -> None:
         # Acceptors don't perform TLS handshake.  Perform the same

--- a/examples/tcp_echo_server.py
+++ b/examples/tcp_echo_server.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import time
-from typing import Optional
+from typing import Any, Optional
 
 from proxy import Proxy
 from proxy.core.base import BaseTcpServerHandler
@@ -18,6 +18,10 @@ from proxy.core.connection import TcpClientConnection
 
 class EchoServerHandler(BaseTcpServerHandler[TcpClientConnection]):
     """Sets client socket to non-blocking during initialization."""
+
+    @staticmethod
+    def create(**kwargs: Any) -> TcpClientConnection:
+        return TcpClientConnection(**kwargs)
 
     def initialize(self) -> None:
         self.work.connection.setblocking(False)

--- a/proxy/core/acceptor/acceptor.py
+++ b/proxy/core/acceptor/acceptor.py
@@ -224,7 +224,8 @@ class Acceptor(multiprocessing.Process):
                 ),
             )
             thread.start()
-            logger.debug(
+            # TODO: Move me into target method
+            logger.debug(   # pragma: no cover
                 'Dispatched work#{0}.{1}.{2} to worker#{3}'.format(
                     conn.fileno(), self.idd, self._total, index,
                 ),
@@ -237,6 +238,7 @@ class Acceptor(multiprocessing.Process):
                 event_queue=self.event_queue,
                 publisher_id=self.__class__.__name__,
             )
+            # TODO: Move me into target method
             logger.debug(   # pragma: no cover
                 'Started work#{0}.{1}.{2} in thread#{3}'.format(
                     conn.fileno(), self.idd, self._total, thread.ident,

--- a/proxy/core/base/tcp_tunnel.py
+++ b/proxy/core/base/tcp_tunnel.py
@@ -47,6 +47,10 @@ class BaseTcpTunnelHandler(BaseTcpServerHandler[TcpClientConnection]):
     def handle_data(self, data: memoryview) -> Optional[bool]:
         pass    # pragma: no cover
 
+    @staticmethod
+    def create(**kwargs: Any) -> TcpClientConnection:
+        return TcpClientConnection(**kwargs)
+
     def initialize(self) -> None:
         self.work.connection.setblocking(False)
 

--- a/proxy/core/connection/pool.py
+++ b/proxy/core/connection/pool.py
@@ -16,7 +16,7 @@ import socket
 import logging
 import selectors
 
-from typing import TYPE_CHECKING, Set, Dict, Tuple
+from typing import TYPE_CHECKING, Any, Set, Dict, Tuple
 
 from ...common.flag import flags
 from ...common.types import Readables, SelectableEvents, Writables
@@ -76,6 +76,10 @@ class UpstreamConnectionPool(Work[TcpServerConnection]):
     def __init__(self) -> None:
         self.connections: Dict[int, TcpServerConnection] = {}
         self.pools: Dict[Tuple[str, int], Set[TcpServerConnection]] = {}
+
+    @staticmethod
+    def create(**kwargs: Any) -> TcpServerConnection:
+        return TcpServerConnection(**kwargs)
 
     def acquire(self, addr: Tuple[str, int]) -> Tuple[bool, TcpServerConnection]:
         """Returns a reusable connection from the pool.
@@ -152,7 +156,7 @@ class UpstreamConnectionPool(Work[TcpServerConnection]):
 
         NOTE: You must not use the returned connection, instead use `acquire`.
         """
-        new_conn = TcpServerConnection(addr[0], addr[1])
+        new_conn = self.create(host=addr[0], port=addr[1])
         new_conn.connect()
         self._add(new_conn)
         logger.debug(

--- a/proxy/core/ssh/handler.py
+++ b/proxy/core/ssh/handler.py
@@ -12,7 +12,7 @@ import argparse
 
 from typing import TYPE_CHECKING, Tuple
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:   # pragma: no cover
     try:
         from paramiko.channel import Channel
     except ImportError:

--- a/proxy/core/ssh/listener.py
+++ b/proxy/core/ssh/listener.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Set, Tuple
 try:
     from paramiko import SSHClient, AutoAddPolicy
     from paramiko.transport import Transport
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:   # pragma: no cover
         from paramiko.channel import Channel
 except ImportError:
     pass

--- a/proxy/core/work/threaded.py
+++ b/proxy/core/work/threaded.py
@@ -12,25 +12,26 @@ import socket
 import argparse
 import threading
 
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple, Type
 
-from ..connection import TcpClientConnection
 from ..event import EventQueue, eventNames
 
 if TYPE_CHECKING:   # pragma: no cover
     from .work import Work
 
 
+# TODO: Add generic T
 def start_threaded_work(
         flags: argparse.Namespace,
         conn: socket.socket,
         addr: Optional[Tuple[str, int]],
         event_queue: Optional[EventQueue] = None,
         publisher_id: Optional[str] = None,
-) -> Tuple['Work[TcpClientConnection]', threading.Thread]:
+) -> Tuple['Work', threading.Thread]:
     """Utility method to start a work in a new thread."""
-    work = flags.work_klass(
-        TcpClientConnection(conn, addr),
+    work_klass: Type['Work'] = flags.work_klass
+    work = work_klass(
+        work_klass.create(conn=conn, addr=addr),
         flags=flags,
         event_queue=event_queue,
         upstream_conn_pool=None,

--- a/proxy/core/work/threaded.py
+++ b/proxy/core/work/threaded.py
@@ -12,12 +12,14 @@ import socket
 import argparse
 import threading
 
-from typing import TYPE_CHECKING, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Optional, Tuple, TypeVar
 
 from ..event import EventQueue, eventNames
 
 if TYPE_CHECKING:   # pragma: no cover
     from .work import Work
+
+T = TypeVar('T')
 
 
 # TODO: Add generic T
@@ -27,11 +29,10 @@ def start_threaded_work(
         addr: Optional[Tuple[str, int]],
         event_queue: Optional[EventQueue] = None,
         publisher_id: Optional[str] = None,
-) -> Tuple['Work', threading.Thread]:
+) -> Tuple['Work[T]', threading.Thread]:
     """Utility method to start a work in a new thread."""
-    work_klass: Type['Work'] = flags.work_klass
-    work = work_klass(
-        work_klass.create(conn=conn, addr=addr),
+    work = flags.work_klass(
+        flags.work_klass.create(conn=conn, addr=addr),
         flags=flags,
         event_queue=event_queue,
         upstream_conn_pool=None,

--- a/proxy/core/work/threadless.py
+++ b/proxy/core/work/threadless.py
@@ -18,14 +18,13 @@ import selectors
 import multiprocessing
 
 from abc import abstractmethod, ABC
-from typing import TYPE_CHECKING, Dict, Optional, Tuple, List, Set, Generic, TypeVar, Union
+from typing import TYPE_CHECKING, Dict, Optional, Tuple, List, Set, Generic, Type, TypeVar, Union
 
 from ...common.logger import Logger
 from ...common.types import Readables, SelectableEvents, Writables
 from ...common.constants import DEFAULT_INACTIVE_CONN_CLEANUP_TIMEOUT, DEFAULT_SELECTOR_SELECT_TIMEOUT
 from ...common.constants import DEFAULT_WAIT_FOR_TASKS_TIMEOUT
 
-from ..connection import TcpClientConnection
 from ..event import eventNames
 
 if TYPE_CHECKING:   # pragma: no cover
@@ -137,8 +136,9 @@ class Threadless(ABC, Generic[T]):
             type=socket.SOCK_STREAM,
         )
         uid = '%s-%s-%s' % (self.iid, self._total, fileno)
-        self.works[fileno] = self.flags.work_klass(
-            TcpClientConnection(
+        work_klass: Type['Work'] = self.flags.work_klass
+        self.works[fileno] = work_klass(
+            work_klass.create(
                 conn=conn,
                 addr=addr,
             ),

--- a/proxy/core/work/threadless.py
+++ b/proxy/core/work/threadless.py
@@ -18,7 +18,7 @@ import selectors
 import multiprocessing
 
 from abc import abstractmethod, ABC
-from typing import TYPE_CHECKING, Dict, Optional, Tuple, List, Set, Generic, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Dict, Optional, Tuple, List, Set, Generic, TypeVar, Union
 
 from ...common.logger import Logger
 from ...common.types import Readables, SelectableEvents, Writables
@@ -136,9 +136,8 @@ class Threadless(ABC, Generic[T]):
             type=socket.SOCK_STREAM,
         )
         uid = '%s-%s-%s' % (self.iid, self._total, fileno)
-        work_klass: Type['Work'] = self.flags.work_klass
-        self.works[fileno] = work_klass(
-            work_klass.create(
+        self.works[fileno] = self.flags.work_klass(
+            self.flags.work_klass.create(
                 conn=conn,
                 addr=addr,
             ),

--- a/proxy/core/work/work.py
+++ b/proxy/core/work/work.py
@@ -47,6 +47,14 @@ class Work(ABC, Generic[T]):
         self.work = work
         self.upstream_conn_pool = upstream_conn_pool
 
+    @staticmethod
+    @abstractmethod
+    def create(**kwargs: Any) -> T:
+        """Implementations are responsible for creation of work objects
+        from incoming args.  This helps keep work core agnostic to
+        creation of externally defined work class objects."""
+        raise NotImplementedError()
+
     @abstractmethod
     async def get_events(self) -> SelectableEvents:
         """Return sockets and events (read or write) that we are interested in."""

--- a/proxy/http/__init__.py
+++ b/proxy/http/__init__.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 from .handler import HttpProtocolHandler
+from .connection import HttpClientConnection
 from .plugin import HttpProtocolHandlerPlugin
 from .codes import httpStatusCodes
 from .methods import httpMethods
@@ -17,6 +18,7 @@ from .url import Url
 
 __all__ = [
     'HttpProtocolHandler',
+    'HttpClientConnection',
     'HttpProtocolHandlerPlugin',
     'httpStatusCodes',
     'httpMethods',

--- a/proxy/http/connection.py
+++ b/proxy/http/connection.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""
+    proxy.py
+    ~~~~~~~~
+    ⚡⚡⚡ Fast, Lightweight, Pluggable, TLS interception capable proxy server focused on
+    Network monitoring, controls & Application development, testing, debugging.
+
+    :copyright: (c) 2013-present by Abhinav Singh and contributors.
+    :license: BSD, see LICENSE for more details.
+
+    .. spelling::
+
+       http
+       iterable
+"""
+from ..core.connection import TcpClientConnection
+
+
+class HttpClientConnection(TcpClientConnection):
+    pass

--- a/proxy/http/handler.py
+++ b/proxy/http/handler.py
@@ -56,6 +56,10 @@ class HttpProtocolHandler(BaseTcpServerHandler[HttpClientConnection]):
     # overrides Work class definitions.
     ##
 
+    @staticmethod
+    def create(**kwargs: Any) -> HttpClientConnection:
+        return HttpClientConnection(**kwargs)
+
     def initialize(self) -> None:
         super().initialize()
         if self._encryption_enabled():

--- a/proxy/http/handler.py
+++ b/proxy/http/handler.py
@@ -19,10 +19,10 @@ import selectors
 from typing import Tuple, List, Type, Optional, Any
 
 from ..core.base import BaseTcpServerHandler
-from ..core.connection import TcpClientConnection
 from ..common.types import Readables, SelectableEvents, Writables
 from ..common.constants import DEFAULT_SELECTOR_SELECT_TIMEOUT
 
+from .connection import HttpClientConnection
 from .exception import HttpProtocolException
 from .plugin import HttpProtocolHandlerPlugin
 from .responses import BAD_REQUEST_RESPONSE_PKT
@@ -32,7 +32,7 @@ from .parser import HttpParser, httpParserStates, httpParserTypes
 logger = logging.getLogger(__name__)
 
 
-class HttpProtocolHandler(BaseTcpServerHandler[TcpClientConnection]):
+class HttpProtocolHandler(BaseTcpServerHandler[HttpClientConnection]):
     """HTTP, HTTPS, HTTP2, WebSockets protocol handler.
 
     Accepts `Client` connection and delegates to HttpProtocolHandlerPlugin.
@@ -58,12 +58,8 @@ class HttpProtocolHandler(BaseTcpServerHandler[TcpClientConnection]):
 
     def initialize(self) -> None:
         super().initialize()
-        # Update client connection reference if connection was wrapped
-        # This is here in `handler` and not `tcp_server` because
-        # `tcp_server` is agnostic to constructing TcpClientConnection
-        # objects.
         if self._encryption_enabled():
-            self.work = TcpClientConnection(
+            self.work = HttpClientConnection(
                 conn=self.work.connection,
                 addr=self.work.addr,
             )

--- a/proxy/http/handler.py
+++ b/proxy/http/handler.py
@@ -204,12 +204,12 @@ class HttpProtocolHandler(BaseTcpServerHandler[TcpClientConnection]):
                 if teardown:
                     return True
             except BrokenPipeError:
-                logger.error(
+                logger.warning(
                     'BrokenPipeError when flushing buffer for client',
                 )
                 return True
             except OSError:
-                logger.error('OSError when flushing buffer to client')
+                logger.warning('OSError when flushing buffer to client')
                 return True
         return False
 

--- a/proxy/http/inspector/inspect_traffic.py
+++ b/proxy/http/inspector/inspect_traffic.py
@@ -16,7 +16,7 @@ from ...core.event import EventSubscriber
 
 from ..websocket import WebsocketFrame, WebSocketTransportBasePlugin
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:   # pragma: no cover
     from ..connection import HttpClientConnection
 
 

--- a/proxy/http/inspector/inspect_traffic.py
+++ b/proxy/http/inspector/inspect_traffic.py
@@ -9,12 +9,15 @@
     :license: BSD, see LICENSE for more details.
 """
 import json
-from typing import List, Dict, Any
+from typing import TYPE_CHECKING, List, Dict, Any
 
 from ...common.utils import bytes_
 from ...core.event import EventSubscriber
-from ...core.connection import TcpClientConnection
+
 from ..websocket import WebsocketFrame, WebSocketTransportBasePlugin
+
+if TYPE_CHECKING:
+    from ..connection import HttpClientConnection
 
 
 class InspectTrafficPlugin(WebSocketTransportBasePlugin):
@@ -58,7 +61,7 @@ class InspectTrafficPlugin(WebSocketTransportBasePlugin):
             raise NotImplementedError()
 
     @staticmethod
-    def callback(client: TcpClientConnection, event: Dict[str, Any]) -> None:
+    def callback(client: 'HttpClientConnection', event: Dict[str, Any]) -> None:
         event['push'] = 'inspect_traffic'
         client.queue(
             memoryview(

--- a/proxy/http/inspector/transformer.py
+++ b/proxy/http/inspector/transformer.py
@@ -19,7 +19,7 @@ from ...core.event import eventNames
 
 from ..websocket import WebsocketFrame
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:   # pragma: no cover
     from ..connection import HttpClientConnection
 
 

--- a/proxy/http/inspector/transformer.py
+++ b/proxy/http/inspector/transformer.py
@@ -10,14 +10,17 @@
 """
 import json
 import time
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
-from ..websocket import WebsocketFrame
 from ...common.constants import PROXY_PY_START_TIME, DEFAULT_DEVTOOLS_DOC_URL
 from ...common.constants import DEFAULT_DEVTOOLS_FRAME_ID, DEFAULT_DEVTOOLS_LOADER_ID
 from ...common.utils import bytes_
-from ...core.connection import TcpClientConnection
 from ...core.event import eventNames
+
+from ..websocket import WebsocketFrame
+
+if TYPE_CHECKING:
+    from ..connection import HttpClientConnection
 
 
 class CoreEventsToDevtoolsProtocol:
@@ -30,7 +33,7 @@ class CoreEventsToDevtoolsProtocol:
 
     @staticmethod
     def transformer(
-        client: TcpClientConnection,
+        client: 'HttpClientConnection',
         event: Dict[str, Any],
     ) -> None:
         event_name = event['event_name']

--- a/proxy/http/plugin.py
+++ b/proxy/http/plugin.py
@@ -15,9 +15,9 @@ from abc import ABC, abstractmethod
 from typing import List, Union, Optional, TYPE_CHECKING
 
 from ..core.event import EventQueue
-from ..core.connection import TcpClientConnection
 
 from .parser import HttpParser
+from .connection import HttpClientConnection
 from .descriptors import DescriptorsHandlerMixin
 from .mixins import TlsInterceptionPropertyMixin
 
@@ -55,7 +55,7 @@ class HttpProtocolHandlerPlugin(
             self,
             uid: str,
             flags: argparse.Namespace,
-            client: TcpClientConnection,
+            client: HttpClientConnection,
             request: HttpParser,
             event_queue: Optional[EventQueue] = None,
             upstream_conn_pool: Optional['UpstreamConnectionPool'] = None,
@@ -63,7 +63,7 @@ class HttpProtocolHandlerPlugin(
         super().__init__(uid, flags, client, event_queue, upstream_conn_pool)
         self.uid: str = uid
         self.flags: argparse.Namespace = flags
-        self.client: TcpClientConnection = client
+        self.client: HttpClientConnection = client
         self.request: HttpParser = request
         self.event_queue = event_queue
         self.upstream_conn_pool = upstream_conn_pool

--- a/proxy/http/proxy/plugin.py
+++ b/proxy/http/proxy/plugin.py
@@ -17,9 +17,9 @@ from ..mixins import TlsInterceptionPropertyMixin
 
 from ..parser import HttpParser
 from ..descriptors import DescriptorsHandlerMixin
+from ..connection import HttpClientConnection
 
 from ...core.event import EventQueue
-from ...core.connection import TcpClientConnection
 
 if TYPE_CHECKING:   # pragma: no cover
     from ...core.connection import UpstreamConnectionPool
@@ -38,7 +38,7 @@ class HttpProxyBasePlugin(
             self,
             uid: str,
             flags: argparse.Namespace,
-            client: TcpClientConnection,
+            client: HttpClientConnection,
             event_queue: EventQueue,
             upstream_conn_pool: Optional['UpstreamConnectionPool'] = None,
     ) -> None:

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -196,7 +196,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                 )
                 return False
             except BrokenPipeError:
-                logger.error(
+                logger.warning(
                     'BrokenPipeError when flushing buffer for server',
                 )
                 return self._close_and_release()
@@ -840,7 +840,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                 )
             do_close = True
         except BrokenPipeError:
-            logger.error(
+            logger.warning(
                 'BrokenPipeError when wrapping client for upstream: {0}'.format(
                     self.upstream.addr[0],
                 ),

--- a/proxy/http/server/plugin.py
+++ b/proxy/http/server/plugin.py
@@ -16,8 +16,8 @@ from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from ..websocket import WebsocketFrame
 from ..parser import HttpParser
 from ..descriptors import DescriptorsHandlerMixin
+from ..connection import HttpClientConnection
 
-from ...core.connection import TcpClientConnection
 from ...core.event import EventQueue
 
 if TYPE_CHECKING:   # pragma: no cover
@@ -31,7 +31,7 @@ class HttpWebServerBasePlugin(DescriptorsHandlerMixin, ABC):
             self,
             uid: str,
             flags: argparse.Namespace,
-            client: TcpClientConnection,
+            client: HttpClientConnection,
             event_queue: EventQueue,
             upstream_conn_pool: Optional['UpstreamConnectionPool'] = None,
     ):

--- a/proxy/http/websocket/plugin.py
+++ b/proxy/http/websocket/plugin.py
@@ -18,7 +18,7 @@ from ...core.event import EventQueue
 
 from . import WebsocketFrame
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:   # pragma: no cover
     from ..connection import HttpClientConnection
 
 

--- a/proxy/http/websocket/plugin.py
+++ b/proxy/http/websocket/plugin.py
@@ -11,12 +11,15 @@
 import argparse
 import json
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any
+from typing import TYPE_CHECKING, List, Dict, Any
 
 from ...common.utils import bytes_
-from . import WebsocketFrame
-from ...core.connection import TcpClientConnection
 from ...core.event import EventQueue
+
+from . import WebsocketFrame
+
+if TYPE_CHECKING:
+    from ..connection import HttpClientConnection
 
 
 class WebSocketTransportBasePlugin(ABC):
@@ -25,7 +28,7 @@ class WebSocketTransportBasePlugin(ABC):
     def __init__(
             self,
             flags: argparse.Namespace,
-            client: TcpClientConnection,
+            client: 'HttpClientConnection',
             event_queue: EventQueue,
     ) -> None:
         self.flags = flags

--- a/tests/core/test_acceptor.py
+++ b/tests/core/test_acceptor.py
@@ -24,9 +24,10 @@ class TestAcceptor(unittest.TestCase):
     def setUp(self) -> None:
         self.acceptor_id = 1
         self.pipe = multiprocessing.Pipe()
+        self.work_klass = mock.MagicMock()
         self.flags = FlagParser.initialize(
             threaded=True,
-            work_klass=mock.MagicMock(),
+            work_klass=self.work_klass,
             local_executor=0,
         )
         self.acceptor = Acceptor(
@@ -63,7 +64,6 @@ class TestAcceptor(unittest.TestCase):
         sock.accept.assert_not_called()
         self.flags.work_klass.assert_not_called()
 
-    @mock.patch('proxy.core.work.threaded.TcpClientConnection')
     @mock.patch('threading.Thread')
     @mock.patch('selectors.DefaultSelector')
     @mock.patch('socket.fromfd')
@@ -74,7 +74,6 @@ class TestAcceptor(unittest.TestCase):
             mock_fromfd: mock.Mock,
             mock_selector: mock.Mock,
             mock_thread: mock.Mock,
-            mock_client: mock.Mock,
     ) -> None:
         fileno = 10
         conn = mock.MagicMock()
@@ -99,7 +98,7 @@ class TestAcceptor(unittest.TestCase):
             type=socket.SOCK_STREAM,
         )
         self.flags.work_klass.assert_called_with(
-            mock_client.return_value,
+            self.work_klass.create.return_value,
             flags=self.flags,
             event_queue=None,
             upstream_conn_pool=None,

--- a/tests/core/test_conn_pool.py
+++ b/tests/core/test_conn_pool.py
@@ -33,7 +33,10 @@ class TestConnectionPool(unittest.TestCase):
         mock_conn.closed = False
         # Acquire
         created, conn = pool.acquire(addr)
-        mock_tcp_server_connection.assert_called_once_with(addr[0], addr[1])
+        mock_tcp_server_connection.assert_called_once_with(
+            host=addr[0],
+            port=addr[1],
+        )
         mock_conn.mark_inuse.assert_called_once()
         mock_conn.reset.assert_not_called()
         self.assertTrue(created)
@@ -66,7 +69,10 @@ class TestConnectionPool(unittest.TestCase):
         # Acquire
         created, conn = pool.acquire(addr)
         self.assertTrue(created)
-        mock_tcp_server_connection.assert_called_once_with(addr[0], addr[1])
+        mock_tcp_server_connection.assert_called_once_with(
+            host=addr[0],
+            port=addr[1],
+        )
         self.assertEqual(conn, mock_conn)
         self.assertEqual(len(pool.pools[addr]), 1)
         self.assertTrue(conn in pool.pools[addr])
@@ -91,7 +97,10 @@ class TestConnectionPoolAsync:
         mock_conn = mock_tcp_server_connection.return_value
         addr = mock_conn.addr
         pool.add(addr)
-        mock_tcp_server_connection.assert_called_once_with(addr[0], addr[1])
+        mock_tcp_server_connection.assert_called_once_with(
+            host=addr[0],
+            port=addr[1],
+        )
         mock_conn.connect.assert_called_once()
         events = await pool.get_events()
         print(events)

--- a/tests/http/exceptions/test_http_proxy_auth_failed.py
+++ b/tests/http/exceptions/test_http_proxy_auth_failed.py
@@ -14,11 +14,10 @@ import pytest
 
 from pytest_mock import MockerFixture
 
-from proxy.http import HttpProtocolHandler, httpHeaders
+from proxy.http import HttpProtocolHandler, httpHeaders, HttpClientConnection
 from proxy.common.flag import FlagParser
 from proxy.common.utils import build_http_request
 from proxy.http.responses import PROXY_AUTH_FAILED_RESPONSE_PKT
-from proxy.core.connection import TcpClientConnection
 from ...test_assertions import Assertions
 
 
@@ -39,7 +38,7 @@ class TestHttpProxyAuthFailed(Assertions):
         )
         self._conn = self.mock_fromfd.return_value
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr),
+            HttpClientConnection(self._conn, self._addr),
             flags=self.flags,
         )
         self.protocol_handler.initialize()

--- a/tests/http/proxy/test_http_proxy.py
+++ b/tests/http/proxy/test_http_proxy.py
@@ -14,12 +14,11 @@ import pytest
 
 from pytest_mock import MockerFixture
 
-from proxy.http import HttpProtocolHandler
+from proxy.http import HttpProtocolHandler, HttpClientConnection
 from proxy.http.proxy import HttpProxyPlugin
 from proxy.common.flag import FlagParser
 from proxy.common.utils import build_http_request
 from proxy.http.exception import HttpProtocolException
-from proxy.core.connection import TcpClientConnection
 from proxy.common.constants import DEFAULT_HTTP_PORT
 
 
@@ -43,7 +42,7 @@ class TestHttpProxyPlugin:
         }
         self._conn = self.mock_fromfd.return_value
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr),
+            HttpClientConnection(self._conn, self._addr),
             flags=self.flags,
         )
         self.protocol_handler.initialize()

--- a/tests/http/proxy/test_http_proxy_tls_interception.py
+++ b/tests/http/proxy/test_http_proxy_tls_interception.py
@@ -19,12 +19,12 @@ from unittest import mock
 
 from pytest_mock import MockerFixture
 
-from proxy.http import HttpProtocolHandler, httpMethods
+from proxy.http import HttpProtocolHandler, httpMethods, HttpClientConnection
 from proxy.http.proxy import HttpProxyPlugin
 from proxy.common.flag import FlagParser
 from proxy.common.utils import bytes_, build_http_request
 from proxy.http.responses import PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT
-from proxy.core.connection import TcpClientConnection, TcpServerConnection
+from proxy.core.connection import TcpServerConnection
 from proxy.common.constants import DEFAULT_CA_FILE
 from ...test_assertions import Assertions
 
@@ -88,7 +88,7 @@ class TestHttpProxyTlsInterception(Assertions):
         }
         self._conn = self.mock_fromfd.return_value
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr),
+            HttpClientConnection(self._conn, self._addr),
             flags=self.flags,
         )
         self.protocol_handler.initialize()

--- a/tests/http/test_protocol_handler.py
+++ b/tests/http/test_protocol_handler.py
@@ -17,7 +17,7 @@ from unittest import mock
 
 from pytest_mock import MockerFixture
 
-from proxy.http import HttpProtocolHandler, httpHeaders
+from proxy.http import HttpProtocolHandler, httpHeaders, HttpClientConnection
 from proxy.http.proxy import HttpProxyPlugin
 from proxy.common.flag import FlagParser
 from proxy.http.parser import HttpParser, httpParserTypes, httpParserStates
@@ -28,7 +28,6 @@ from proxy.http.responses import (
     BAD_GATEWAY_RESPONSE_PKT, PROXY_AUTH_FAILED_RESPONSE_PKT,
     PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT,
 )
-from proxy.core.connection import TcpClientConnection
 from proxy.common.constants import (
     CRLF, PLUGIN_HTTP_PROXY, PLUGIN_PROXY_AUTH, PLUGIN_WEB_SERVER,
 )
@@ -68,7 +67,7 @@ class TestHttpProtocolHandlerWithoutServerMock(Assertions):
         ])
 
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr),
+            HttpClientConnection(self._conn, self._addr),
             flags=self.flags,
         )
         self.protocol_handler.initialize()
@@ -101,7 +100,7 @@ class TestHttpProtocolHandlerWithoutServerMock(Assertions):
             bytes_(PLUGIN_PROXY_AUTH),
         ])
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr), flags=flags,
+            HttpClientConnection(self._conn, self._addr), flags=flags,
         )
         self.protocol_handler.initialize()
         self._conn.recv.return_value = CRLF.join([
@@ -138,7 +137,7 @@ class TestHttpProtocolHandler(Assertions):
         ])
 
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr),
+            HttpClientConnection(self._conn, self._addr),
             flags=self.flags,
         )
         self.protocol_handler.initialize()
@@ -301,7 +300,7 @@ class TestHttpProtocolHandler(Assertions):
         ])
 
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr), flags=flags,
+            HttpClientConnection(self._conn, self._addr), flags=flags,
         )
         self.protocol_handler.initialize()
         assert self.http_server_port is not None
@@ -349,7 +348,7 @@ class TestHttpProtocolHandler(Assertions):
         ])
 
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr), flags=flags,
+            HttpClientConnection(self._conn, self._addr), flags=flags,
         )
         self.protocol_handler.initialize()
 

--- a/tests/http/web/test_web_server.py
+++ b/tests/http/web/test_web_server.py
@@ -18,13 +18,12 @@ import pytest
 
 from pytest_mock import MockerFixture
 
-from proxy.http import HttpProtocolHandler
+from proxy.http import HttpProtocolHandler, HttpClientConnection
 from proxy.common.flag import FlagParser
 from proxy.http.parser import HttpParser, httpParserTypes, httpParserStates
 from proxy.common.utils import bytes_, build_http_request, build_http_response
 from proxy.common.plugins import Plugins
 from proxy.http.responses import NOT_FOUND_RESPONSE_PKT
-from proxy.core.connection import TcpClientConnection
 from proxy.common.constants import (
     CRLF, PROXY_PY_DIR, PLUGIN_PAC_FILE, PLUGIN_HTTP_PROXY, PLUGIN_WEB_SERVER,
 )
@@ -48,7 +47,7 @@ def test_on_client_connection_called_on_teardown(mocker: MockerFixture) -> None:
     _conn = mock_fromfd.return_value
     _addr = ('127.0.0.1', 54382)
     protocol_handler = HttpProtocolHandler(
-        TcpClientConnection(_conn, _addr),
+        HttpClientConnection(_conn, _addr),
         flags=flags,
     )
     protocol_handler.initialize()
@@ -81,7 +80,7 @@ def mock_selector_for_client_read(self: Any) -> None:
 #     flags.plugins = {b'HttpProtocolHandlerPlugin': [plugin]}
 #     self._conn = mock_fromfd.return_value
 #     self.protocol_handler = HttpProtocolHandler(
-#         TcpClientConnection(self._conn, self._addr),
+#         HttpClientConnection(self._conn, self._addr),
 #         flags=flags,
 #     )
 #     self.protocol_handler.initialize()
@@ -101,7 +100,7 @@ def mock_selector_for_client_read(self: Any) -> None:
 #     flags.plugins = {b'HttpProtocolHandlerPlugin': [plugin]}
 #     self._conn = mock_fromfd.return_value
 #     self.protocol_handler = HttpProtocolHandler(
-#         TcpClientConnection(self._conn, self._addr),
+#         HttpClientConnection(self._conn, self._addr),
 #         flags=flags,
 #     )
 #     self.protocol_handler.initialize()
@@ -121,7 +120,7 @@ def mock_selector_for_client_read(self: Any) -> None:
 #     flags.plugins = {b'HttpProtocolHandlerPlugin': [plugin]}
 #     self._conn = mock_fromfd.return_value
 #     self.protocol_handler = HttpProtocolHandler(
-#         TcpClientConnection(self._conn, self._addr),
+#         HttpClientConnection(self._conn, self._addr),
 #         flags=flags,
 #     )
 #     self.protocol_handler.initialize()
@@ -162,7 +161,7 @@ class TestWebServerPluginWithPacFilePlugin(Assertions):
             bytes_(PLUGIN_PAC_FILE),
         ])
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr),
+            HttpClientConnection(self._conn, self._addr),
             flags=self.flags,
         )
         self.protocol_handler.initialize()
@@ -221,7 +220,7 @@ class TestStaticWebServerPlugin(Assertions):
             bytes_(PLUGIN_WEB_SERVER),
         ])
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr),
+            HttpClientConnection(self._conn, self._addr),
             flags=flags,
         )
         self.protocol_handler.initialize()
@@ -328,7 +327,7 @@ class TestWebServerPlugin(Assertions):
             bytes_(PLUGIN_WEB_SERVER),
         ])
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr),
+            HttpClientConnection(self._conn, self._addr),
             flags=self.flags,
         )
         self.protocol_handler.initialize()
@@ -353,7 +352,7 @@ class TestWebServerPlugin(Assertions):
             bytes_(PLUGIN_WEB_SERVER),
         ])
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr),
+            HttpClientConnection(self._conn, self._addr),
             flags=flags,
         )
         self.protocol_handler.initialize()

--- a/tests/plugin/test_http_proxy_plugins.py
+++ b/tests/plugin/test_http_proxy_plugins.py
@@ -20,13 +20,12 @@ from unittest import mock
 
 from pytest_mock import MockerFixture
 
-from proxy.http import HttpProtocolHandler, httpStatusCodes
+from proxy.http import HttpProtocolHandler, httpStatusCodes, HttpClientConnection
 from proxy.plugin import ProposedRestApiPlugin, RedirectToCustomServerPlugin
 from proxy.http.proxy import HttpProxyPlugin
 from proxy.common.flag import FlagParser
 from proxy.http.parser import HttpParser, httpParserTypes
 from proxy.common.utils import bytes_, build_http_request, build_http_response
-from proxy.core.connection import TcpClientConnection
 from proxy.common.constants import DEFAULT_HTTP_PORT, PROXY_AGENT_HEADER_VALUE
 from .utils import get_plugin_by_test_name
 from ..test_assertions import Assertions
@@ -64,7 +63,7 @@ class TestHttpProxyPluginExamples(Assertions):
         }
         self._conn = self.mock_fromfd.return_value
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr),
+            HttpClientConnection(self._conn, self._addr),
             flags=self.flags,
         )
         self.protocol_handler.initialize()

--- a/tests/plugin/test_http_proxy_plugins_with_tls_interception.py
+++ b/tests/plugin/test_http_proxy_plugins_with_tls_interception.py
@@ -18,7 +18,7 @@ import pytest
 
 from pytest_mock import MockerFixture
 
-from proxy.http import HttpProtocolHandler, httpMethods
+from proxy.http import HttpProtocolHandler, httpMethods, HttpClientConnection
 from proxy.http.proxy import HttpProxyPlugin
 from proxy.common.flag import FlagParser
 from proxy.http.parser import HttpParser, httpParserTypes
@@ -26,7 +26,7 @@ from proxy.common.utils import bytes_, build_http_request
 from proxy.http.responses import (
     PROXY_TUNNEL_ESTABLISHED_RESPONSE_PKT, okResponse,
 )
-from proxy.core.connection import TcpClientConnection, TcpServerConnection
+from proxy.core.connection import TcpServerConnection
 from .utils import get_plugin_by_test_name
 from ..test_assertions import Assertions
 
@@ -71,7 +71,7 @@ class TestHttpProxyPluginExamplesWithTlsInterception(Assertions):
         self._conn = mocker.MagicMock(spec=socket.socket)
         self.mock_fromfd.return_value = self._conn
         self.protocol_handler = HttpProtocolHandler(
-            TcpClientConnection(self._conn, self._addr), flags=self.flags,
+            HttpClientConnection(self._conn, self._addr), flags=self.flags,
         )
         self.protocol_handler.initialize()
 


### PR DESCRIPTION
## This PR
- Adds `HttpClientConnection` skeleton, now used by HTTP layer core and plugins
- Make `work` core agnostic to work object construction e.g. `TcpClientConnection`, `HttpClientConnection` and other work objects must now be constructed by the implementation themselves using incoming `**kwargs`.

## Related PR
- https://github.com/abhinavsingh/proxy.py/pull/993

## Agenda: All plugins must use client.response not client.queue

Using `client.queue` works but imposes challenges for outgoing response handling/customization/inspection.  Instead all plugins must now call `client.response`.  Internally, it works the same as `client.queue`.  Just that now, plugins must queue a `HttpParser`, `WebsocketFrame` etc objects instead of `memoryview` or raw `bytes`.

By doing so it becomes possible for the core to provide a response based callback eco-system e.g. proxy plugins can modify/update responses queued by other plugins (currently only a single plugin can technically send response).  Also, we'll be able to add `middleware` support for proxy and web server plugins.

Note that `client.queue` itself will continue to work.  Just that such plugins will not be able to take advantage of core capabilities that will depend upon plugins use of `client.response`.   At some point in far future, `client.queue` method will be made private.
