### PR TITLE
[Windows] Fix broken `--local-executor` logic for windows

### DIFF
--- a/proxy/core/acceptor/acceptor.py
+++ b/proxy/core/acceptor/acceptor.py
@@ -148,7 +148,8 @@ class Acceptor(multiprocessing.Process):
                 if locked:
                     self.lock.release()
             for work in works:
-                if self.flags.local_executor == int(DEFAULT_LOCAL_EXECUTOR):
+                if self.flags.threadless and \
+                        self.flags.local_executor:
                     assert self._local_work_queue
                     self._local_work_queue.put(work)
                 else:
@@ -171,7 +172,7 @@ class Acceptor(multiprocessing.Process):
             type=socket.SOCK_STREAM,
         )
         try:
-            if self.flags.local_executor == int(DEFAULT_LOCAL_EXECUTOR):
+            if self.flags.threadless and self.flags.local_executor:
                 self._start_local()
             self.selector.register(self.sock, selectors.EVENT_READ)
             while not self.running.is_set():
@@ -180,7 +181,7 @@ class Acceptor(multiprocessing.Process):
             pass
         finally:
             self.selector.unregister(self.sock)
-            if self.flags.local_executor == int(DEFAULT_LOCAL_EXECUTOR):
+            if self.flags.threadless and self.flags.local_executor:
                 self._stop_local()
             self.sock.close()
             logger.debug('Acceptor#%d shutdown', self.idd)

--- a/proxy/core/work/threadless.py
+++ b/proxy/core/work/threadless.py
@@ -429,7 +429,7 @@ class Threadless(ABC, Generic[T]):
                     data=wqfileno,
                 )
             assert self.loop
-            # logger.debug('Working on {0} works'.format(len(self.works)))
+            logger.debug('Working on {0} works'.format(len(self.works)))
             self.loop.create_task(self._run_forever())
             self.loop.run_forever()
         except KeyboardInterrupt:

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -25,7 +25,7 @@ from .core.acceptor import AcceptorPool, Listener
 
 from .common.utils import bytes_
 from .common.flag import FlagParser, flags
-from .common.constants import DEFAULT_ENABLE_SSH_TUNNEL, DEFAULT_LOCAL_EXECUTOR, DEFAULT_LOG_FILE
+from .common.constants import DEFAULT_ENABLE_SSH_TUNNEL, DEFAULT_LOG_FILE
 from .common.constants import DEFAULT_OPEN_FILE_LIMIT, DEFAULT_PLUGINS, DEFAULT_VERSION
 from .common.constants import DEFAULT_ENABLE_DASHBOARD, DEFAULT_WORK_KLASS, DEFAULT_PID_FILE
 from .common.constants import DEFAULT_LOG_FORMAT, DEFAULT_LOG_LEVEL, IS_WINDOWS
@@ -242,7 +242,7 @@ class Proxy:
     @property
     def remote_executors_enabled(self) -> bool:
         return self.flags.threadless and \
-            not (self.flags.local_executor == int(DEFAULT_LOCAL_EXECUTOR))
+            not self.flags.local_executor
 
     def _write_pid_file(self) -> None:
         if self.flags.pid_file:


### PR DESCRIPTION
Due to broken logic, local executor thread was getting started even in the threadless mode, resulting in a broken experience.

- Fixes https://github.com/abhinavsingh/proxy.py/issues/1000