### PR TITLE
[Windows] Remove `--threadless` from `TestCase`

### DIFF
--- a/proxy/testing/test_case.py
+++ b/proxy/testing/test_case.py
@@ -28,7 +28,6 @@ class TestCase(unittest.TestCase):
         '--port', '0',
         '--num-workers', '1',
         '--num-acceptors', '1',
-        '--threadless',
     ]
 
     PROXY: Optional[Proxy] = None

--- a/tests/http/proxy/test_http2.py
+++ b/tests/http/proxy/test_http2.py
@@ -8,20 +8,13 @@
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
 """
-import pytest
-
 import httpx
 
 from proxy import TestCase
-from proxy.common.constants import IS_WINDOWS
 
 
 class TestHttp2WithProxy(TestCase):
 
-    @pytest.mark.skipif(
-        IS_WINDOWS,
-        reason='--threadless not supported on Windows',
-    )  # type: ignore[misc]
     def test_http2_via_proxy(self) -> None:
         assert self.PROXY
         response = httpx.get(

--- a/tests/testing/test_embed.py
+++ b/tests/testing/test_embed.py
@@ -12,21 +12,15 @@ import http.client
 import urllib.error
 import urllib.request
 
-import pytest
-
 from proxy import TestCase
 from proxy.http import httpMethods
 from proxy.common.utils import socket_connection, build_http_request
 from proxy.http.responses import NOT_FOUND_RESPONSE_PKT
 from proxy.common.constants import (
-    IS_WINDOWS, PROXY_AGENT_HEADER_VALUE, DEFAULT_CLIENT_RECVBUF_SIZE,
+    PROXY_AGENT_HEADER_VALUE, DEFAULT_CLIENT_RECVBUF_SIZE,
 )
 
 
-@pytest.mark.skipif(
-    IS_WINDOWS,
-    reason='Disabled for Windows due to weird permission issues.',
-)
 class TestProxyPyEmbedded(TestCase):
     """This test case is a demonstration of proxy.TestCase and also serves as
     integration test suite for proxy.py."""


### PR DESCRIPTION
- Enable `http2` and `embedded` test case for windows