### PR TITLE
[CacheResponsesPlugin] Add ability to cache request packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2284,7 +2284,7 @@ usage: -m [-h] [--tunnel-hostname TUNNEL_HOSTNAME] [--tunnel-port TUNNEL_PORT]
           [--ca-cert-file CA_CERT_FILE] [--ca-file CA_FILE]
           [--ca-signing-key-file CA_SIGNING_KEY_FILE]
           [--auth-plugin AUTH_PLUGIN] [--cache-dir CACHE_DIR]
-          [--proxy-pool PROXY_POOL] [--enable-web-server]
+          [--cache-requests] [--proxy-pool PROXY_POOL] [--enable-web-server]
           [--enable-static-server] [--static-server-dir STATIC_SERVER_DIR]
           [--min-compression-length MIN_COMPRESSION_LENGTH]
           [--enable-reverse-proxy] [--pac-file PAC_FILE]
@@ -2425,6 +2425,7 @@ options:
                         Default: /Users/abhinavsingh/.proxy/cache. Flag only
                         applicable when cache plugin is used with on-disk
                         storage.
+  --cache-requests      Default: False. Whether to also cache request packets.
   --proxy-pool PROXY_POOL
                         List of upstream proxies to use in the pool
   --enable-web-server   Default: False. Whether to enable

--- a/proxy/common/constants.py
+++ b/proxy/common/constants.py
@@ -148,6 +148,7 @@ DEFAULT_DATA_DIRECTORY_PATH = os.path.join(str(pathlib.Path.home()), '.proxy')
 DEFAULT_CACHE_DIRECTORY_PATH = os.path.join(
     DEFAULT_DATA_DIRECTORY_PATH, 'cache',
 )
+DEFAULT_CACHE_REQUESTS = False
 
 # Cor plugins enabled by default or via flags
 DEFAULT_ABC_PLUGINS = [

--- a/proxy/http/handler.py
+++ b/proxy/http/handler.py
@@ -163,9 +163,7 @@ class HttpProtocolHandler(BaseTcpServerHandler[HttpClientConnection]):
             self.work.closed = True
             return True
         try:
-            # Don't parse incoming data any further after 1st request has completed.
-            #
-            # This specially does happen for pipeline requests.
+            # We don't parse incoming data any further after 1st HTTP request packet.
             #
             # Plugins can utilize on_client_data for such cases and
             # apply custom logic to handle request data sent after 1st
@@ -173,11 +171,10 @@ class HttpProtocolHandler(BaseTcpServerHandler[HttpClientConnection]):
             if self.request.state != httpParserStates.COMPLETE:
                 if self._parse_first_request(data):
                     return True
-            else:
-                # HttpProtocolHandlerPlugin.on_client_data
-                # Can raise HttpProtocolException to tear down the connection
-                if self.plugin:
-                    data = self.plugin.on_client_data(data) or data
+            # HttpProtocolHandlerPlugin.on_client_data
+            # Can raise HttpProtocolException to tear down the connection
+            elif self.plugin:
+                data = self.plugin.on_client_data(data) or data
         except HttpProtocolException as e:
             logger.info('HttpProtocolException: %s' % e)
             response: Optional[memoryview] = e.response(self.request)

--- a/proxy/http/handler.py
+++ b/proxy/http/handler.py
@@ -174,7 +174,7 @@ class HttpProtocolHandler(BaseTcpServerHandler[HttpClientConnection]):
             # HttpProtocolHandlerPlugin.on_client_data
             # Can raise HttpProtocolException to tear down the connection
             elif self.plugin:
-                data = self.plugin.on_client_data(data) or data
+                self.plugin.on_client_data(data)
         except HttpProtocolException as e:
             logger.info('HttpProtocolException: %s' % e)
             response: Optional[memoryview] = e.response(self.request)

--- a/proxy/http/plugin.py
+++ b/proxy/http/plugin.py
@@ -71,9 +71,9 @@ class HttpProtocolHandlerPlugin(
         raise NotImplementedError()
 
     @abstractmethod
-    def on_client_data(self, raw: memoryview) -> Optional[memoryview]:
+    def on_client_data(self, raw: memoryview) -> None:
         """Called only after original request has been completely received."""
-        return raw  # pragma: no cover
+        pass    # pragma: no cover
 
     @abstractmethod
     def on_request_complete(self) -> Union[socket.socket, bool]:

--- a/proxy/http/proxy/plugin.py
+++ b/proxy/http/proxy/plugin.py
@@ -121,7 +121,6 @@ class HttpProxyBasePlugin(
         Return None to drop the request data, e.g. in case a response has already been queued.
         Raise HttpRequestRejected or HttpProtocolException directly to
         tear down the connection with client.
-
         """
         return request  # pragma: no cover
 

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -413,7 +413,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
             for plugin in self.plugins.values():
                 o = plugin.handle_client_data(raw)
                 if o is None:
-                    return None
+                    return
                 raw = o
         elif self.upstream and not self.upstream.closed:
             # For http proxy requests, handle pipeline case.
@@ -429,7 +429,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                     # upgrade request. Incoming client data now
                     # must be treated as WebSocket protocol packets.
                     self.upstream.queue(raw)
-                    return None
+                    return
 
                 if self.pipeline_request is None:
                     # For pipeline requests, we never
@@ -452,7 +452,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                         assert self.pipeline_request is not None
                         r = plugin.handle_client_request(self.pipeline_request)
                         if r is None:
-                            return None
+                            return
                         self.pipeline_request = r
                     assert self.pipeline_request is not None
                     # TODO(abhinavsingh): Remove memoryview wrapping here after

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -398,7 +398,7 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
         return chunk
 
     # Can return None to tear down connection
-    def on_client_data(self, raw: memoryview) -> Optional[memoryview]:
+    def on_client_data(self, raw: memoryview) -> None:
         # For scenarios when an upstream connection was never established,
         # let plugin do whatever they wish to.  These are special scenarios
         # where plugins are trying to do something magical.  Within the core
@@ -468,8 +468,6 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
             # simply queue for upstream server.
             else:
                 self.upstream.queue(raw)
-            return None
-        return raw
 
     def on_request_complete(self) -> Union[socket.socket, bool]:
         self.emit_request_complete()

--- a/proxy/http/proxy/server.py
+++ b/proxy/http/proxy/server.py
@@ -435,6 +435,11 @@ class HttpProxyPlugin(HttpProtocolHandlerPlugin):
                     # For pipeline requests, we never
                     # want to use --enable-proxy-protocol flag
                     # as proxy protocol header will not be present
+                    #
+                    # TODO: HTTP parser must be smart about detecting
+                    # HA proxy protocol or we must always explicitly pass
+                    # the flag when we are expecting HA proxy protocol
+                    # request line before HTTP request lines.
                     self.pipeline_request = HttpParser(
                         httpParserTypes.REQUEST_PARSER,
                     )

--- a/proxy/http/server/web.py
+++ b/proxy/http/server/web.py
@@ -194,7 +194,7 @@ class HttpWebServerPlugin(HttpProtocolHandlerPlugin):
                 return True
         return False
 
-    def on_client_data(self, raw: memoryview) -> Optional[memoryview]:
+    def on_client_data(self, raw: memoryview) -> None:
         if self.switched_protocol == httpProtocolTypes.WEBSOCKET:
             # TODO(abhinavsingh): Remove .tobytes after websocket frame parser
             # is memoryview compliant
@@ -231,7 +231,6 @@ class HttpWebServerPlugin(HttpProtocolHandlerPlugin):
                         'Pipelined request is not keep-alive, will tear down request...',
                     )
                 self.pipeline_request = None
-        return raw
 
     def on_response_chunk(self, chunk: List[memoryview]) -> List[memoryview]:
         return chunk

--- a/proxy/http/server/web.py
+++ b/proxy/http/server/web.py
@@ -211,7 +211,7 @@ class HttpWebServerPlugin(HttpProtocolHandlerPlugin):
                     assert self.route
                     self.route.on_websocket_message(frame)
                 frame.reset()
-            return None
+            return
         # If 1st valid request was completed and it's a HTTP/1.1 keep-alive
         # And only if we have a route, parse pipeline requests
         if self.request.is_complete and \

--- a/proxy/plugin/cache/cache_responses.py
+++ b/proxy/plugin/cache/cache_responses.py
@@ -30,6 +30,7 @@ class CacheResponsesPlugin(BaseCacheResponsesPlugin):
                 self.flags.cache_dir,
                 'responses',
             ),
+            cache_requests=self.flags.cache_requests,
         )
         self.set_store(self.disk_store)
 

--- a/proxy/plugin/cache/store/disk.py
+++ b/proxy/plugin/cache/store/disk.py
@@ -43,9 +43,10 @@ flags.add_argument(
 
 class OnDiskCacheStore(CacheStore):
 
-    def __init__(self, uid: str, cache_dir: str) -> None:
+    def __init__(self, uid: str, cache_dir: str, cache_requests: bool) -> None:
         super().__init__(uid)
         self.cache_dir = cache_dir
+        self.cache_requests = cache_requests
         self.cache_file_path: Optional[str] = None
         self.cache_file: Optional[BinaryIO] = None
 
@@ -57,7 +58,7 @@ class OnDiskCacheStore(CacheStore):
         self.cache_file = open(self.cache_file_path, "wb")
 
     def cache_request(self, request: HttpParser) -> Optional[HttpParser]:
-        if self.cache_file:
+        if self.cache_file and self.cache_requests:
             self.cache_file.write(request.build())
         return request
 

--- a/proxy/plugin/cache/store/disk.py
+++ b/proxy/plugin/cache/store/disk.py
@@ -16,7 +16,9 @@ from .base import CacheStore
 from ....common.flag import flags
 from ....http.parser import HttpParser
 from ....common.utils import text_
-from ....common.constants import DEFAULT_CACHE_DIRECTORY_PATH
+from ....common.constants import (
+    DEFAULT_CACHE_REQUESTS, DEFAULT_CACHE_DIRECTORY_PATH,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -28,6 +30,14 @@ flags.add_argument(
     default=DEFAULT_CACHE_DIRECTORY_PATH,
     help='Default: ' + DEFAULT_CACHE_DIRECTORY_PATH + '.  ' +
     'Flag only applicable when cache plugin is used with on-disk storage.',
+)
+
+flags.add_argument(
+    '--cache-requests',
+    action='store_true',
+    default=DEFAULT_CACHE_REQUESTS,
+    help='Default: False.  ' +
+    'Whether to also cache request packets.',
 )
 
 
@@ -47,6 +57,8 @@ class OnDiskCacheStore(CacheStore):
         self.cache_file = open(self.cache_file_path, "wb")
 
     def cache_request(self, request: HttpParser) -> Optional[HttpParser]:
+        if self.cache_file:
+            self.cache_file.write(request.build())
         return request
 
     def cache_response_chunk(self, chunk: memoryview) -> memoryview:

--- a/tests/http/proxy/test_http_proxy_tls_interception.py
+++ b/tests/http/proxy/test_http_proxy_tls_interception.py
@@ -127,7 +127,7 @@ class TestHttpProxyTlsInterception(Assertions):
         )
         client_tls_sock.recv.return_value = get_request
 
-        T = TypeVar('T')
+        T = TypeVar('T')    # noqa: N806
 
         async def asyncReturn(val: T) -> T:
             return val

--- a/tests/http/proxy/test_http_proxy_tls_interception.py
+++ b/tests/http/proxy/test_http_proxy_tls_interception.py
@@ -195,7 +195,8 @@ class TestHttpProxyTlsInterception(Assertions):
 
         # Invoked lifecycle callbacks
         self.proxy_plugin.return_value.resolve_dns.assert_called_once_with(
-            host, port)
+            host, port,
+        )
         self.proxy_plugin.return_value.before_upstream_connection.assert_called()
         self.proxy_plugin.return_value.handle_client_request.assert_called_once()
         self.proxy_plugin.return_value.do_intercept.assert_called_once()
@@ -279,7 +280,8 @@ class TestHttpProxyTlsInterception(Assertions):
         self.proxy_plugin.return_value.on_access_log.assert_not_called()
         # Only handle client request lifecycle must be called again
         self.proxy_plugin.return_value.resolve_dns.assert_called_once_with(
-            host, port)
+            host, port,
+        )
         self.proxy_plugin.return_value.before_upstream_connection.assert_called()
         self.assertEqual(
             self.proxy_plugin.return_value.handle_client_request.call_count,

--- a/tests/http/proxy/test_http_proxy_tls_interception.py
+++ b/tests/http/proxy/test_http_proxy_tls_interception.py
@@ -209,6 +209,7 @@ class TestHttpProxyTlsInterception(Assertions):
             self.proxy_plugin.return_value.do_intercept.call_args_list[0][0][0]
         self.assertEqual(callback_request.host, bytes_(host))
         self.assertEqual(callback_request.port, 443)
+        self.assertEqual(callback_request.header(b'Host'), headers[b'Host'])
         assert callback_request._url
         self.assertEqual(callback_request._url.remainder, None)
         self.assertEqual(callback_request.method, httpMethods.CONNECT)
@@ -285,3 +286,13 @@ class TestHttpProxyTlsInterception(Assertions):
             2,
         )
         self.proxy_plugin.return_value.do_intercept.assert_called_once()
+
+        callback_request = \
+            self.proxy_plugin.return_value.handle_client_request.call_args_list[1][0][0]
+        self.assertEqual(callback_request.host, None)
+        self.assertEqual(callback_request.port, 80)
+        self.assertEqual(callback_request.header(b'Host'), headers[b'Host'])
+        assert callback_request._url
+        self.assertEqual(callback_request._url.remainder, b'/')
+        self.assertEqual(callback_request.method, httpMethods.GET)
+        self.assertEqual(callback_request.is_https_tunnel, False)


### PR DESCRIPTION
- Use `--cache-requests` flag, by default `CacheResponsesPlugin` will only write response packets
- Also, added unit tests for post interception lifecycle callbacks