### PR TITLE
[Fix] Using `okResponse()` without content hangs the connection

### DIFF
--- a/proxy/common/utils.py
+++ b/proxy/common/utils.py
@@ -111,17 +111,13 @@ def build_http_response(
         line.append(reason)
     if headers is None:
         headers = {}
-    has_content_length = False
     has_transfer_encoding = False
     for k, _ in headers.items():
-        if k.lower() == b'content-length':
-            has_content_length = True
         if k.lower() == b'transfer-encoding':
             has_transfer_encoding = True
-    if body is not None and \
-            not has_transfer_encoding and \
-            not has_content_length:
-        headers[b'Content-Length'] = bytes_(len(body))
+            break
+    if not has_transfer_encoding:
+        headers[b'Content-Length'] = bytes_(len(body)) if body else b'0'
     return build_http_pkt(line, headers, body, conn_close)
 
 

--- a/tests/http/exceptions/test_http_request_rejected.py
+++ b/tests/http/exceptions/test_http_request_rejected.py
@@ -31,6 +31,7 @@ class TestHttpRequestRejected(unittest.TestCase):
         self.assertEqual(
             e.response(self.request), CRLF.join([
                 b'HTTP/1.1 200 OK',
+                b'Content-Length: 0',
                 b'Connection: close',
                 CRLF,
             ]),

--- a/tests/http/parser/test_http_parser.py
+++ b/tests/http/parser/test_http_parser.py
@@ -146,6 +146,7 @@ class TestHttpParser(unittest.TestCase):
             okResponse(protocol_version=b'HTTP/1.1'),
             CRLF.join([
                 b'HTTP/1.1 200 OK',
+                b'Content-Length: 0',
                 CRLF,
             ]),
         )
@@ -157,6 +158,7 @@ class TestHttpParser(unittest.TestCase):
             CRLF.join([
                 b'HTTP/1.1 200 OK',
                 b'key: value',
+                b'Content-Length: 0',
                 CRLF,
             ]),
         )


### PR DESCRIPTION
- It hangs because of no content-length or connection close header
- Fixes https://github.com/abhinavsingh/proxy.py/issues/1028