### PR TITLE
[Jupyter] Request creation notebook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,7 +127,7 @@ repos:
   - id: codespell
     exclude: >
       (?x)^(
-        tutorial/responses.ipynb|
+        tutorial/*.ipynb|
         tests/http/test_responses\.py|
         ^.+\.min\.js$
       )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,7 +127,7 @@ repos:
   - id: codespell
     exclude: >
       (?x)^(
-        tutorial/*.ipynb|
+        ^.+\.ipynb$|
         tests/http/test_responses\.py|
         ^.+\.min\.js$
       )$

--- a/README.md
+++ b/README.md
@@ -2297,7 +2297,7 @@ usage: -m [-h] [--tunnel-hostname TUNNEL_HOSTNAME] [--tunnel-port TUNNEL_PORT]
           [--filtered-client-ips FILTERED_CLIENT_IPS]
           [--filtered-url-regex-config FILTERED_URL_REGEX_CONFIG]
 
-proxy.py v2.4.0rc8.dev17+g59a4335.d20220123
+proxy.py v2.4.0rc9.dev8+gea0253d.d20220126
 
 options:
   -h, --help            show this help message and exit

--- a/proxy/common/utils.py
+++ b/proxy/common/utils.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, List, Type, Tuple, Callable, Optional
 from .types import HostPort
 from .constants import (
     CRLF, COLON, HTTP_1_1, IS_WINDOWS, WHITESPACE, DEFAULT_TIMEOUT,
-    DEFAULT_THREADLESS,
+    DEFAULT_THREADLESS, PROXY_AGENT_HEADER_VALUE,
 )
 
 
@@ -84,14 +84,30 @@ def bytes_(s: Any, encoding: str = 'utf-8', errors: str = 'strict') -> Any:
 def build_http_request(
     method: bytes, url: bytes,
     protocol_version: bytes = HTTP_1_1,
+    content_type: Optional[bytes] = None,
     headers: Optional[Dict[bytes, bytes]] = None,
     body: Optional[bytes] = None,
     conn_close: bool = False,
+    no_ua: bool = False,
 ) -> bytes:
     """Build and returns a HTTP request packet."""
+    headers = headers or {}
+    if content_type is not None:
+        headers[b'Content-Type'] = content_type
+    has_transfer_encoding = False
+    has_user_agent = False
+    for k, _ in headers.items():
+        if k.lower() == b'transfer-encoding':
+            has_transfer_encoding = True
+        elif k.lower() == b'user-agent':
+            has_user_agent = True
+    if body and not has_transfer_encoding:
+        headers[b'Content-Length'] = bytes_(len(body))
+    if not has_user_agent and not no_ua:
+        headers[b'User-Agent'] = PROXY_AGENT_HEADER_VALUE
     return build_http_pkt(
         [method, url, protocol_version],
-        headers or {},
+        headers,
         body,
         conn_close,
     )
@@ -109,8 +125,7 @@ def build_http_response(
     line = [protocol_version, bytes_(status_code)]
     if reason:
         line.append(reason)
-    if headers is None:
-        headers = {}
+    headers = headers or {}
     has_transfer_encoding = False
     for k, _ in headers.items():
         if k.lower() == b'transfer-encoding':

--- a/proxy/http/parser/parser.py
+++ b/proxy/http/parser/parser.py
@@ -270,6 +270,7 @@ class HttpParser:
                 k.lower() not in disable_headers
             },
             body=body,
+            no_ua=True,
         )
 
     def build_response(self) -> bytes:

--- a/proxy/plugin/__init__.py
+++ b/proxy/plugin/__init__.py
@@ -11,6 +11,8 @@
     .. spelling::
 
        Cloudflare
+       ws
+       onmessage
 """
 from .cache import CacheResponsesPlugin, BaseCacheResponsesPlugin
 from .shortlink import ShortLinkPlugin

--- a/proxy/plugin/modify_post_data.py
+++ b/proxy/plugin/modify_post_data.py
@@ -34,7 +34,7 @@ class ModifyPostDataPlugin(HttpProxyBasePlugin):
             body = ModifyPostDataPlugin.MODIFIED_BODY
             # If the request is of type chunked encoding
             # add post data as chunk
-            if not request.is_chunked_encoded:
+            if request.is_chunked_encoded:
                 body = ChunkParser.to_chunks(
                     ModifyPostDataPlugin.MODIFIED_BODY,
                 )

--- a/proxy/plugin/web_server_route.py
+++ b/proxy/plugin/web_server_route.py
@@ -40,4 +40,11 @@ class WebServerPlugin(HttpWebServerBasePlugin):
             self.client.queue(HTTPS_RESPONSE)
 
     def on_websocket_message(self, frame: WebsocketFrame) -> None:
+        """Open chrome devtools and try using following commands:
+
+        ws = new WebSocket("ws://localhost:8899/ws-route-example")
+        ws.onmessage = function(m) { console.log(m); }
+        ws.send('hello')
+
+        """
         self.client.queue(memoryview(WebsocketFrame.text(frame.data or b'')))

--- a/proxy/plugin/web_server_route.py
+++ b/proxy/plugin/web_server_route.py
@@ -14,6 +14,7 @@ from typing import List, Tuple
 from ..http.parser import HttpParser
 from ..http.server import HttpWebServerBasePlugin, httpProtocolTypes
 from ..http.responses import okResponse
+from ..http.websocket.frame import WebsocketFrame
 
 
 logger = logging.getLogger(__name__)
@@ -37,3 +38,6 @@ class WebServerPlugin(HttpWebServerBasePlugin):
             self.client.queue(HTTP_RESPONSE)
         elif request.path == b'/https-route-example':
             self.client.queue(HTTPS_RESPONSE)
+
+    def on_websocket_message(self, frame: WebsocketFrame) -> None:
+        self.client.queue(memoryview(WebsocketFrame.text(frame.data or b'')))

--- a/proxy/plugin/web_server_route.py
+++ b/proxy/plugin/web_server_route.py
@@ -7,6 +7,11 @@
 
     :copyright: (c) 2013-present by Abhinav Singh and contributors.
     :license: BSD, see LICENSE for more details.
+
+    .. spelling::
+
+       ws
+       onmessage
 """
 import logging
 from typing import List, Tuple
@@ -42,9 +47,11 @@ class WebServerPlugin(HttpWebServerBasePlugin):
     def on_websocket_message(self, frame: WebsocketFrame) -> None:
         """Open chrome devtools and try using following commands:
 
-        ws = new WebSocket("ws://localhost:8899/ws-route-example")
-        ws.onmessage = function(m) { console.log(m); }
-        ws.send('hello')
+        Example:
+
+            ws = new WebSocket("ws://localhost:8899/ws-route-example")
+            ws.onmessage = function(m) { console.log(m); }
+            ws.send('hello')
 
         """
         self.client.queue(memoryview(WebsocketFrame.text(frame.data or b'')))

--- a/tests/http/parser/test_http_parser.py
+++ b/tests/http/parser/test_http_parser.py
@@ -124,7 +124,7 @@ class TestHttpParser(unittest.TestCase):
     def test_build_request(self) -> None:
         self.assertEqual(
             build_http_request(
-                b'GET', b'http://localhost:12345', b'HTTP/1.1',
+                b'GET', b'http://localhost:12345', b'HTTP/1.1', no_ua=True,
             ),
             CRLF.join([
                 b'GET http://localhost:12345 HTTP/1.1',
@@ -135,6 +135,7 @@ class TestHttpParser(unittest.TestCase):
             build_http_request(
                 b'GET', b'http://localhost:12345', b'HTTP/1.1',
                 headers={b'key': b'value'},
+                no_ua=True,
             ),
             CRLF.join([
                 b'GET http://localhost:12345 HTTP/1.1',
@@ -147,10 +148,12 @@ class TestHttpParser(unittest.TestCase):
                 b'GET', b'http://localhost:12345', b'HTTP/1.1',
                 headers={b'key': b'value'},
                 body=b'Hello from py',
+                no_ua=True,
             ),
             CRLF.join([
                 b'GET http://localhost:12345 HTTP/1.1',
                 b'key: value',
+                b'Content-Length: 13',
                 CRLF,
             ]) + b'Hello from py',
         )

--- a/tests/http/proxy/test_http_proxy_tls_interception.py
+++ b/tests/http/proxy/test_http_proxy_tls_interception.py
@@ -119,6 +119,7 @@ class TestHttpProxyTlsInterception(Assertions):
         connect_request = build_http_request(
             httpMethods.CONNECT, bytes_(netloc),
             headers=headers,
+            no_ua=True,
         )
         self._conn.recv.return_value = connect_request
         get_request = build_http_request(

--- a/tests/plugin/test_http_proxy_plugins.py
+++ b/tests/plugin/test_http_proxy_plugins.py
@@ -93,6 +93,7 @@ class TestHttpProxyPluginExamples(Assertions):
                 b'Content-Length': bytes_(len(original)),
             },
             body=original,
+            no_ua=True,
         )
         self.mock_selector.return_value.select.side_effect = [
             [(
@@ -120,6 +121,7 @@ class TestHttpProxyPluginExamples(Assertions):
                     b'Via': b'1.1 %s' % PROXY_AGENT_HEADER_VALUE,
                 },
                 body=modified,
+                no_ua=True,
             ),
         )
 
@@ -189,6 +191,7 @@ class TestHttpProxyPluginExamples(Assertions):
             headers={
                 b'Host': b'example.org',
             },
+            no_ua=True,
         )
         self._conn.recv.return_value = request
         self.mock_selector.return_value.select.side_effect = [
@@ -215,6 +218,7 @@ class TestHttpProxyPluginExamples(Assertions):
                     b'Host': upstream.netloc,
                     b'Via': b'1.1 %s' % PROXY_AGENT_HEADER_VALUE,
                 },
+                no_ua=True,
             ),
         )
 
@@ -305,6 +309,7 @@ class TestHttpProxyPluginExamples(Assertions):
             headers={
                 b'Host': b'super.secure',
             },
+            no_ua=True,
         )
         self._conn.recv.return_value = request
 
@@ -363,8 +368,12 @@ class TestHttpProxyPluginExamples(Assertions):
                     b'Host': b'super.secure',
                     b'Via': b'1.1 %s' % PROXY_AGENT_HEADER_VALUE,
                 },
+                no_ua=True,
             )
-        server.queue.assert_called_once_with(queued_request)
+        server.queue.assert_called_once()
+        print(server.queue.call_args_list[0][0][0].tobytes())
+        print(queued_request)
+        self.assertEqual(server.queue.call_args_list[0][0][0], queued_request)
 
         # Server write
         await self.protocol_handler._run_once()
@@ -514,6 +523,7 @@ class TestHttpProxyPluginExamples(Assertions):
             headers={
                 b'Host': b'jaxl.com',
             },
+            no_ua=True,
         )
         self._conn.recv.return_value = request
 
@@ -537,6 +547,7 @@ class TestHttpProxyPluginExamples(Assertions):
                     b'Host': b'jaxl.com',
                     b'Via': b'1.1 %s' % PROXY_AGENT_HEADER_VALUE,
                 },
+                no_ua=True,
             ),
         )
         self.assertFalse(self.protocol_handler.work.has_buffer())

--- a/tests/plugin/test_http_proxy_plugins_with_tls_interception.py
+++ b/tests/plugin/test_http_proxy_plugins_with_tls_interception.py
@@ -152,7 +152,9 @@ class TestHttpProxyPluginExamplesWithTlsInterception(Assertions):
 
         self._conn.send.side_effect = send
         self._conn.recv.return_value = build_http_request(
-            httpMethods.CONNECT, b'uni.corn:443',
+            httpMethods.CONNECT,
+            b'uni.corn:443',
+            no_ua=True,
         )
 
     @pytest.mark.asyncio    # type: ignore[misc]
@@ -193,6 +195,7 @@ class TestHttpProxyPluginExamplesWithTlsInterception(Assertions):
                 b'Content-Type': b'application/x-www-form-urlencoded',
             },
             body=original,
+            no_ua=True,
         )
         await self.protocol_handler._run_once()
         self.server.queue.assert_called_once()
@@ -242,6 +245,7 @@ class TestHttpProxyPluginExamplesWithTlsInterception(Assertions):
             headers={
                 b'Host': b'uni.corn',
             },
+            no_ua=True,
         )
         self.client_ssl_connection.recv.return_value = request
 

--- a/tests/plugin/utils.py
+++ b/tests/plugin/utils.py
@@ -11,9 +11,9 @@
 from typing import Type
 
 from proxy.plugin import (
-    CacheResponsesPlugin, ManInTheMiddlePlugin, ModifyPostDataPlugin,
-    ProposedRestApiPlugin, FilterByURLRegexPlugin, FilterByUpstreamHostPlugin,
-    RedirectToCustomServerPlugin,
+    ShortLinkPlugin, CacheResponsesPlugin, ManInTheMiddlePlugin,
+    ModifyPostDataPlugin, ProposedRestApiPlugin, FilterByURLRegexPlugin,
+    FilterByUpstreamHostPlugin, RedirectToCustomServerPlugin,
 )
 from proxy.http.proxy import HttpProxyBasePlugin
 
@@ -34,4 +34,6 @@ def get_plugin_by_test_name(test_name: str) -> Type[HttpProxyBasePlugin]:
         plugin = ManInTheMiddlePlugin
     elif test_name == 'test_filter_by_url_regex_plugin':
         plugin = FilterByURLRegexPlugin
+    elif test_name == 'test_shortlink_plugin':
+        plugin = ShortLinkPlugin
     return plugin

--- a/tutorial/requests.ipynb
+++ b/tutorial/requests.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Http Requests\n",
+    "\n",
+    "## Usage\n",
+    "\n",
+    "To construct a HTTP request packet you have a variety of facilities available.\n",
+    "\n",
+    "Previously we saw how to parse HTTP responses using `HttpParser`.  We also saw how `HttpParser` class is capable of parsing various type of HTTP protocols.  Remember the _take away_ from that tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b'GET / HTTP/1.1\\r\\nHost: jaxl.com\\r\\nUser-Agent: proxy.py v2.4.0rc9.dev8+gea0253d.d20220126\\r\\n\\r\\n'\n"
+     ]
+    }
+   ],
+   "source": [
+    "from proxy.http.parser import HttpParser, httpParserTypes\n",
+    "from proxy.http import httpMethods\n",
+    "from proxy.common.utils import HTTP_1_1\n",
+    "\n",
+    "request = HttpParser(httpParserTypes.REQUEST_PARSER)\n",
+    "request.path, request.method, request.version = b'/', httpMethods.GET, HTTP_1_1\n",
+    "request.add_header(b'Host', b'jaxl.com')\n",
+    "\n",
+    "print(request.build())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But, this is a painful way to construct request packets.  Hence, other high level abstractions are available.\n",
+    "\n",
+    "Example, following one liner will give us the same request packet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'GET / HTTP/1.1\\r\\nHost: jaxl.com\\r\\nUser-Agent: proxy.py v2.4.0rc9.dev8+gea0253d.d20220126\\r\\n\\r\\n'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from proxy.common.utils import build_http_request\n",
+    "\n",
+    "build_http_request(\n",
+    "    method=httpMethods.GET,\n",
+    "    url=b'/',\n",
+    "    headers={b'Host': b'jaxl.com'},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`build_http_request` ensures a `User-Agent` header.  You can provide your own too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'GET / HTTP/1.1\\r\\nHost: jaxl.com\\r\\nUser-Agent: my app v1\\r\\n\\r\\n'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "build_http_request(\n",
+    "    method=httpMethods.GET,\n",
+    "    url=b'/',\n",
+    "    headers={\n",
+    "        b'Host': b'jaxl.com',\n",
+    "        b'User-Agent': b'my app v1'\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or, if you don't want a `User-Agent` header at all"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'GET / HTTP/1.1\\r\\nHost: jaxl.com\\r\\n\\r\\n'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "build_http_request(\n",
+    "    method=httpMethods.GET,\n",
+    "    url=b'/',\n",
+    "    headers={b'Host': b'jaxl.com'},\n",
+    "    no_ua=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To add a connection close header, simply pass `conn_close=True`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'GET / HTTP/1.1\\r\\nHost: jaxl.com\\r\\nUser-Agent: proxy.py v2.4.0rc9.dev8+gea0253d.d20220126\\r\\nConnection: close\\r\\n\\r\\n'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "build_http_request(\n",
+    "    method=httpMethods.GET,\n",
+    "    url=b'/',\n",
+    "    headers={b'Host': b'jaxl.com'},\n",
+    "    conn_close=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For `POST` requests, provide the `body` attribute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'POST / HTTP/1.1\\r\\nHost: jaxl.com\\r\\nContent-Type: application/x-www-form-urlencoded\\r\\nContent-Length: 21\\r\\nUser-Agent: proxy.py v2.4.0rc9.dev8+gea0253d.d20220126\\r\\nConnection: close\\r\\n\\r\\nkey=value&hello=world'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "build_http_request(\n",
+    "    method=httpMethods.POST,\n",
+    "    url=b'/',\n",
+    "    headers={b'Host': b'jaxl.com'},\n",
+    "    body=b'key=value&hello=world',\n",
+    "    content_type=b'application/x-www-form-urlencoded',\n",
+    "    conn_close=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For chunked data, simply include a `Transfer-Encoding` header.  This will omit the `Content-Length` header then:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'POST / HTTP/1.1\\r\\nHost: jaxl.com\\r\\nTransfer-Encoding: chunked\\r\\nContent-Type: application/x-www-form-urlencoded\\r\\nUser-Agent: proxy.py v2.4.0rc9.dev8+gea0253d.d20220126\\r\\nConnection: close\\r\\n\\r\\n5\\r\\nkey=v\\r\\n5\\r\\nalue&\\r\\n5\\r\\nhello\\r\\n5\\r\\n=worl\\r\\n1\\r\\nd\\r\\n0\\r\\n\\r\\n'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from proxy.http.parser import ChunkParser\n",
+    "\n",
+    "build_http_request(\n",
+    "    method=httpMethods.POST,\n",
+    "    url=b'/',\n",
+    "    headers={\n",
+    "        b'Host': b'jaxl.com',\n",
+    "        b'Transfer-Encoding': b'chunked',\n",
+    "    },\n",
+    "    body=ChunkParser.to_chunks(b'key=value&hello=world', chunk_size=5),\n",
+    "    content_type=b'application/x-www-form-urlencoded',\n",
+    "    conn_close=True,\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "da9d6927d62b2b95bde149eedfbd5367cb7f465aad65a736f49c99ee3db39df7"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.10.0 64-bit ('venv310': venv)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorial/responses.ipynb
+++ b/tutorial/responses.ipynb
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {

--- a/tutorial/responses.ipynb
+++ b/tutorial/responses.ipynb
@@ -8,9 +8,9 @@
     "\n",
     "## Usage\n",
     "\n",
-    "To construct a response packet you have a variety of facilities available.  We previously experienced how to parse HTTP responses using `HttpParser`.  Of-course, we can also construct a response packet using `HttpParser` class.\n",
+    "To construct a response packet you have a variety of facilities available.\n",
     "\n",
-    "Let's construct a HTTP response packet:"
+    "Previously we saw how to parse HTTP responses using `HttpParser`.  Of-course, we can also construct a response packet using `HttpParser` class."
    ]
   },
   {
@@ -42,7 +42,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But it is a little painful to construct responses like above.  Hence, other high level abstractions are available.\n",
+    "But, this is a painful way to construct responses.  Hence, other high level abstractions are available.\n",
     "\n",
     "Example, following one liner will give us the same response packet."
    ]


### PR DESCRIPTION
- Also added missing tests to the plugin
- `build_http_request` utility changes:
  - Now always adds `User-Agent` header, unless `no_ua` or a custom header has not already been provided
  - Now adds/update the `Content-Length` header if body is present