### PR TITLE
Avoid installing `!=7.0.0,!=7.0.1,!=7.0.2` which leads to 0.0 as wheel version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ requires = [
   "setuptools",
 
   # Plugins
-  "setuptools-scm[toml] >= 6",
-  "setuptools-scm-git-archive >= 1.1",
+  "setuptools-scm[toml]>=6,!=7.0.0,!=7.0.1,!=7.0.2",
+  "setuptools-scm-git-archive>=1.1",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Ref
- https://github.com/pypa/setuptools_scm/issues/727
- https://github.com/abhinavsingh/proxy.py/issues/642#issuecomment-1167634666