### PR TITLE
Pyre type error fixed.

### DIFF
--- a/proxy/http/parser/parser.py
+++ b/proxy/http/parser/parser.py
@@ -357,7 +357,7 @@ class HttpParser:
         #
         # See TestHttpParser.test_issue_398 scenario
         self.state = httpParserStates.RCVING_BODY
-        self.body = raw
+        self.body = bytes(raw)
         return False, memoryview(b'')
 
     def _process_headers(self, raw: memoryview) -> Tuple[bool, memoryview]:


### PR DESCRIPTION
**"filename"**: "proxy/http/parser/parser.py"
**"warning_type"**: "Incompatible attribute type [8]"
**"warning_message"**: " Attribute `body` declared in class `HttpParser` has type `Optional[bytes]` but is used as type `memoryview`."
**"warning_line"**: 360
**"fix"**: bytes(raw)
