### PR TITLE
Remove `codecov` from dependency files

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -10,7 +10,6 @@ pytest-asyncio==0.16.0
 autopep8==1.6.0
 mypy==0.971
 py-spy==0.3.12
-codecov==2.1.12
 tox==3.25.1
 mccabe==0.6.1
 pylint==2.13.7


### PR DESCRIPTION
- See https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader
- Causing failures like these https://github.com/abhinavsingh/proxy.py/actions/runs/4713506748/jobs/8359255297?pr=1325