### PR TITLE
Fix not enough items to use struct.pack

### DIFF
--- a/proxy/http/websocket/frame.py
+++ b/proxy/http/websocket/frame.py
@@ -121,7 +121,7 @@ class WebsocketFrame:
         elif self.payload_length < 1 << 64:
             raw.write(
                 struct.pack(
-                    '!BHQ',
+                    '!BQ',
                     (1 << 7 if self.masked else 0) | 127,
                     self.payload_length,
                 ),


### PR DESCRIPTION
This frame headers requires just a byte and a 8 bytes payload length, so replace old "!BHQ" to "!BQ"