### PR TITLE
`compress` option for `serve_static_file` utility method

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -439,7 +439,7 @@ jobs:
       # max-parallel: 4
       matrix:
         os:
-        - macOS-latest
+        - macOS-12
         - Ubuntu-20.04
         - Windows-latest
         python:
@@ -694,7 +694,7 @@ jobs:
     name: 📊 Node ${{ matrix.node }} @ ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macOS-latest]
+        os: [ubuntu-20.04, windows-latest, macOS-12]
         node: ['10.x', '11.x', '12.x']
       # max-parallel: 4
       fail-fast: false

--- a/proxy/common/constants.py
+++ b/proxy/common/constants.py
@@ -125,8 +125,11 @@ DEFAULT_HTTP_PROXY_ACCESS_LOG_FORMAT = '{client_ip}:{client_port} - ' + \
 DEFAULT_HTTPS_PROXY_ACCESS_LOG_FORMAT = '{client_ip}:{client_port} - ' + \
     '{request_method} {server_host}:{server_port} - ' + \
     '{response_bytes} bytes - {connection_time_ms}ms'
-DEFAULT_REVERSE_PROXY_ACCESS_LOG_FORMAT = '{client_ip}:{client_port} - ' + \
-    '{request_method} {request_path} -> {upstream_proxy_pass} - {connection_time_ms}ms'
+DEFAULT_REVERSE_PROXY_ACCESS_LOG_FORMAT = (
+    "{client_ip}:{client_port} - "
+    + "{request_method} {request_path} - {request_ua} -> "
+    + "{upstream_proxy_pass} - {connection_time_ms}ms"
+)
 DEFAULT_NUM_ACCEPTORS = 0
 DEFAULT_NUM_WORKERS = 0
 DEFAULT_OPEN_FILE_LIMIT = 1024

--- a/proxy/http/handler.py
+++ b/proxy/http/handler.py
@@ -181,7 +181,7 @@ class HttpProtocolHandler(BaseTcpServerHandler[HttpClientConnection]):
             elif self.plugin:
                 self.plugin.on_client_data(data)
         except HttpProtocolException as e:
-            logger.info('HttpProtocolException: %s' % e)
+            logger.warning('HttpProtocolException: %s' % e)
             response: Optional[memoryview] = e.response(self.request)
             if response:
                 self.work.queue(response)
@@ -209,9 +209,10 @@ class HttpProtocolHandler(BaseTcpServerHandler[HttpClientConnection]):
                     'BrokenPipeError when flushing buffer for client',
                 )
                 return True
-            except OSError:
-                logger.warning(     # pragma: no cover
+            except OSError as exc:
+                logger.exception(  # pragma: no cover
                     'OSError when flushing buffer to client',
+                    exc_info=exc,
                 )
                 return True
         return False

--- a/proxy/http/server/plugin.py
+++ b/proxy/http/server/plugin.py
@@ -47,7 +47,11 @@ class HttpWebServerBasePlugin(DescriptorsHandlerMixin, ABC):
         self.upstream_conn_pool = upstream_conn_pool
 
     @staticmethod
-    def serve_static_file(path: str, min_compression_length: int) -> memoryview:
+    def serve_static_file(
+        path: str,
+        min_compression_length: int,
+        compress: bool = False,
+    ) -> memoryview:
         try:
             with open(path, 'rb') as f:
                 content = f.read()
@@ -61,6 +65,7 @@ class HttpWebServerBasePlugin(DescriptorsHandlerMixin, ABC):
             return okResponse(
                 content=content,
                 headers=headers,
+                compress=compress,
                 min_compression_length=min_compression_length,
                 # TODO: Should we really close or take advantage of keep-alive?
                 conn_close=True,

--- a/proxy/http/server/plugin.py
+++ b/proxy/http/server/plugin.py
@@ -50,7 +50,7 @@ class HttpWebServerBasePlugin(DescriptorsHandlerMixin, ABC):
     def serve_static_file(
         path: str,
         min_compression_length: int,
-        compress: bool = False,
+        compress: bool = True,
     ) -> memoryview:
         try:
             with open(path, 'rb') as f:


### PR DESCRIPTION
- When files are too big, default `compress: True` can because of blocker
- Added option to not compress, alternately could have also be controlled via min_compression_length, which is a global variable and applies to all served files