### PR TITLE
Created Whitelist Plugin c.f. filter_by_upstream (also fixed latter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
     - [Mock Api Plugin](#mockrestapiplugin)
     - [Redirect To Custom Server Plugin](#redirecttocustomserverplugin)
     - [Filter By Upstream Host Plugin](#filterbyupstreamhostplugin)
+    - [Whitelist_Upstream_Hosts_Plugin](#whitelistupstreamhostplugin)
     - [Cache Responses Plugin](#cacheresponsesplugin)
     - [Cache By Response Type](#cachebyresponsetype)
     - [Man-In-The-Middle Plugin](#maninthemiddleplugin)
@@ -729,6 +730,12 @@ Traceback (most recent call last):
 ... [redacted] ...
 ... [redacted] ... - access_log:1157 - ::1:49911 - GET None:None/ - None None - 0 bytes
 ```
+### WhitelistUpstreamHostPlugin
+
+Essentially the same as [Filter By Upstream Host Plugin](#filterbyupstreamhostplugin)
+except the list of hosts are whitelisted, all others are dropped as being tea-pots that don't serve coffee.
+
+Can take a comma-separated (no-space) list of domains to construct whitelist. Otherwise The whitelist defaults to datasets.datalad.org,singularity-hub.org (because the author needed singularity to run on workernodes in an HPC setting with no NAT to the outside world). 
 
 ### CacheResponsesPlugin
 

--- a/proxy/plugin/__init__.py
+++ b/proxy/plugin/__init__.py
@@ -35,6 +35,7 @@ from .modify_chunk_response import ModifyChunkResponsePlugin
 from .modify_request_header import ModifyRequestHeaderPlugin
 from .redirect_to_custom_server import RedirectToCustomServerPlugin
 from .tls_intercept_conditionally import TlsInterceptConditionallyPlugin
+from .whitelist_upstream_hosts import WhitelistUpstreamHostsPlugin
 
 
 __all__ = [
@@ -57,4 +58,5 @@ __all__ = [
     'ProgramNamePlugin',
     'ModifyRequestHeaderPlugin',
     'TlsInterceptConditionallyPlugin',
+    'WhitelistUpstreamHostsPlugin',
 ]

--- a/proxy/plugin/filter_by_upstream.py
+++ b/proxy/plugin/filter_by_upstream.py
@@ -22,7 +22,7 @@ flags.add_argument(
     '--filtered-upstream-hosts',
     type=str,
     default='facebook.com,www.facebook.com',
-    help='Default: Blocks Facebook.  Comma separated list of IPv4 and IPv6 addresses.',
+    help='Default: Blocks Facebook.  Comma separated list of fully qualified domain names, e.g. "facebook.com,www.facebook.com".',
 )
 
 
@@ -32,7 +32,7 @@ class FilterByUpstreamHostPlugin(HttpProxyBasePlugin):
     def before_upstream_connection(
             self, request: HttpParser,
     ) -> Optional[HttpParser]:
-        if text_(request.host) in self.flags.filtered_upstream_hosts.split(','):
+        if request.host.decode() in self.flags.filtered_upstream_hosts.split(','):
             raise HttpRequestRejected(
                 status_code=httpStatusCodes.I_AM_A_TEAPOT,
                 reason=b'I\'m a tea pot',

--- a/proxy/plugin/whitelist_upstream_hosts.py
+++ b/proxy/plugin/whitelist_upstream_hosts.py
@@ -23,7 +23,7 @@ from ..http.exception import HttpRequestRejected
 flags.add_argument(
     '--whitelist-upstream-hosts',
     type=str,
-    default='datasets.datalad.org,singularity-hub.org',
+    default='datasets.datalad.org,singularity-hub.org,galaxy-dev.mcfe.itservices.manchester.ac.uk',
     help='Default: Allows Singularity and Datasets.  Comma separated list of domains.',
 )
 
@@ -36,6 +36,6 @@ class WhitelistUpstreamHostsPlugin(HttpProxyBasePlugin):
         if not request.host.decode() in self.flags.whitelist_upstream_hosts.split(','):
             raise HttpRequestRejected(
                 status_code=httpStatusCodes.I_AM_A_TEAPOT,
-                reason=b'I\'m a tea pot',
+                reason=b'I\'m a tea pot cannot conect to '+request.host,
             )
         return request

--- a/proxy/plugin/whitelist_upstream_hosts.py
+++ b/proxy/plugin/whitelist_upstream_hosts.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+    proxy.py
+    ~~~~~~~~
+    ⚡⚡⚡ Fast, Lightweight, Pluggable, TLS interception capable proxy server focused on
+    Network monitoring, controls & Application development, testing, debugging.
+
+    :copyright: (c) 2013-present by Abhinav Singh and contributors.
+    :license: BSD, see LICENSE for more details.
+
+    Whitelist Plugin modified from (broken) filter_by_upstream plugin by Mike Jones dr.mike.jones@gmail.com
+
+"""
+from typing import Optional
+
+from ..http import httpStatusCodes
+from ..http.proxy import HttpProxyBasePlugin
+from ..common.flag import flags
+from ..http.parser import HttpParser
+from ..common.utils import text_
+from ..http.exception import HttpRequestRejected
+
+flags.add_argument(
+    '--whitelist-upstream-hosts',
+    type=str,
+    default='datasets.datalad.org,singularity-hub.org',
+    help='Default: Allows Singularity and Datasets.  Comma separated list of domains.',
+)
+
+
+class WhitelistUpstreamHostsPlugin(HttpProxyBasePlugin):
+    """Drop traffic by inspecting upstream host."""
+    def before_upstream_connection(
+            self, request: HttpParser,
+    ) -> Optional[HttpParser]:
+        if not request.host.decode() in self.flags.whitelist_upstream_hosts.split(','):
+            raise HttpRequestRejected(
+                status_code=httpStatusCodes.I_AM_A_TEAPOT,
+                reason=b'I\'m a tea pot',
+            )
+        return request


### PR DESCRIPTION
1. Fixed the Filter By Upstream Plugin so that it compares server-name against the defined/default comma separated filter list of server-names. It was trying instead to match IP address of incoming requesting to the same list of server-names and therefore never matching e.g. the example facebook.com.
2. Made a copy of that Filter By Upstream Plugin, called it Whitelist Upstream Hosts Plugin, and changed code so that the filter behaves in the opposite way: default deny with only matching server-name requests allowed via proxy.
3. Updated __init__.py to allow loading of plugin. 
4. Updated Readme to add info on Plugin.

The reason for this code change was that I wanted a proxy to run on the head node (or associated VM) of an HPC cluster such that a job submitted to the queue, when running on worker nodes with no outbound connection, could set $HTTPS_PROXY to allow singularity to contact the Singularity Hub for required containers to download at runtime. I did not want my proxy to be used as a generic outbound proxy except to pass traffic to Singularity hub and known dependencies at time of writing.

Code was patched on remote HPC which is using an older branch installed via pip. This pull request is against the current development branch, pulled gie pip and git and tested in my local Ubuntu 22.04 environment.

Thank you for your work on proxy.py it has helped work round a singular issue :-)