### PR TITLE
Clarify README wrt ephemeral port in embedded mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1725,7 +1725,7 @@ In embedded mode, you can access this port.  Example:
 import proxy
 
 if __name__ == '__main__':
-  with proxy.Proxy() as p:
+  with proxy.Proxy(port=0) as p:
     print(p.flags.port)
     proxy.sleep_loop()
 ```

--- a/docs/changelog-fragments.d/1524.doc.md
+++ b/docs/changelog-fragments.d/1524.doc.md
@@ -1,0 +1,1 @@
+Clarify documentation for using ephemeral ports in embedded mode.


### PR DESCRIPTION
If we don't set port=0, the default port 8899 is used, so I propose to show port=0 so the embedded mode example matches the CLI example above.

I found this while working on https://github.com/pypa/pip/pull/13234

Thanks for maintaining this project!



